### PR TITLE
Adopt open-source logger and statsd conventions.

### DIFF
--- a/dissemination.go
+++ b/dissemination.go
@@ -3,8 +3,7 @@ package ringpop
 import (
 	"math"
 	"sync"
-
-	log "github.com/Sirupsen/logrus"
+	log "github.com/uber/bark"
 )
 
 var log10 = math.Log(10)

--- a/forward.go
+++ b/forward.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/uber/bark"
 	"github.com/uber/tchannel/golang/json"
 )
 
@@ -116,7 +116,7 @@ func handleForwardRequest(ringpop *Ringpop, headers *forwardReqHeader, pReq *for
 
 	if err := json.CallPeer(ctx, peer, pReq.Header.Service, pReq.Header.Operation, pReq,
 		&res); err != nil {
-		log.Fatalf("json.Call failed: %v", err)
+		ringpop.logger.Fatalf("json.Call failed: %v", err)
 	}
 
 	ringpop.logger.WithFields(log.Fields{

--- a/forward_sender.go
+++ b/forward_sender.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/uber/bark"
 	"github.com/uber/tchannel/golang/json"
 )
 

--- a/gossip.go
+++ b/gossip.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/uber/bark"
 
 	"github.com/rcrowley/go-metrics"
 )

--- a/join_sender.go
+++ b/join_sender.go
@@ -8,7 +8,7 @@ import (
 
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/uber/bark"
 	"github.com/uber/tchannel/golang/json"
 )
 

--- a/membership_update_rollup.go
+++ b/membership_update_rollup.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 )
-import log "github.com/Sirupsen/logrus"
+import log "github.com/uber/bark"
 
 const defaultMaxNumUpdates = 250
 

--- a/ping_handler.go
+++ b/ping_handler.go
@@ -1,6 +1,6 @@
 package ringpop
 
-import log "github.com/Sirupsen/logrus"
+import log "github.com/uber/bark"
 
 func handlePing(ringpop *Ringpop, body pingBody) pingBody {
 	ringpop.stat("increment", "ping.recv", 1)

--- a/ping_req_handler.go
+++ b/ping_req_handler.go
@@ -1,6 +1,6 @@
 package ringpop
 
-import log "github.com/Sirupsen/logrus"
+import log "github.com/uber/bark"
 
 func handlePingReq(ringpop *Ringpop, body pingReqBody) pingReqRes {
 	ringpop.stat("increment", "ping-req.recv", 1)

--- a/ping_req_sender.go
+++ b/ping_req_sender.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/uber/bark"
 	"github.com/uber/tchannel/golang/json"
 )
 

--- a/ping_sender.go
+++ b/ping_sender.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/uber/bark"
 	"github.com/uber/tchannel/golang/json"
 )
 

--- a/replicator.go
+++ b/replicator.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/uber/bark"
 )
 
 // replica consts

--- a/server.go
+++ b/server.go
@@ -3,7 +3,7 @@ package ringpop
 import (
 	"errors"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/uber/bark"
 	"github.com/uber/tchannel/golang"
 	"github.com/uber/tchannel/golang/json"
 	"golang.org/x/net/context"
@@ -100,11 +100,9 @@ func (s *server) statsHandler(ctx json.Context, arg *arg) (map[string]interface{
 }
 
 func (s *server) debugSetHandler(ctx json.Context, arg *arg) (res *arg, err error) {
-	s.ringpop.logger.Level = log.DebugLevel
-	return
+	return nil, errors.New("Debug set not supported")
 }
 
 func (s *server) debugClearHandler(ctx json.Context, arg *arg) (res *arg, err error) {
-	s.ringpop.logger.Level = log.InfoLevel
-	return
+	return nil, errors.New("Debug clear not supported")
 }

--- a/suspicion.go
+++ b/suspicion.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/uber/bark"
 )
 
 const defaultSuspicionTimeout = time.Millisecond * 5000

--- a/util.go
+++ b/util.go
@@ -9,7 +9,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	bark "github.com/uber/bark"
+	logrus "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel/golang"
 )
@@ -119,7 +120,7 @@ func newServerRingpop(t *testing.T, hostport string) *Ringpop {
 	channel, err := tchannel.NewChannel("ringpop", nil)
 	require.NoError(t, err, "error must be nil")
 
-	logger := log.New()
+	logger := logrus.New()
 	logger.Out = ioutil.Discard
 
 	ringpop := NewRingpop("test", hostport, channel, &Options{
@@ -130,13 +131,13 @@ func newServerRingpop(t *testing.T, hostport string) *Ringpop {
 }
 
 func testPop(hostport string, incarnation int64, opts *Options) *Ringpop {
-	logger := log.New()
+	logger := logrus.New()
 	logger.Out = ioutil.Discard
 
 	if opts == nil {
 		opts = &Options{}
 	}
-	opts.Logger = logger
+	opts.Logger = bark.NewLoggerFromLogrus(logger)
 
 	testCh, _ := tchannel.NewChannel("test-service", nil)
 	ringpop := NewRingpop("test", hostport, testCh, opts)


### PR DESCRIPTION
Note: disabling endpoints that currently directly set the logging
level on the logger passed to ringpop.  That isn't currently supported on the
public interface and also seems like dubious  citizenship (the logger
may well be shared with other libraries and application code), though
we can debate that position.  I would propose doing something closer to what
ringpop-js does, with its own level management, in a soon-to-follow-on diff.
