### PR TITLE
Fix issue with example for forwarded pings.

### DIFF
--- a/examples/ping-ring/main.go
+++ b/examples/ping-ring/main.go
@@ -72,7 +72,7 @@ func (w *worker) PingHandler(ctx json.Context, ping *Ping) (*Pong, error) {
 	var pong Pong
 	var res []byte
 
-	handle, err := w.ringpop.HandleOrForward(ping.Key, ping.Bytes(), &res, "ping", "/ping", nil)
+	handle, err := w.ringpop.HandleOrForward(ping.Key, ping.Bytes(), &res, "ping", "/ping", tchannel.JSON, nil)
 	if handle {
 		return &Pong{"Hello, world!", w.ringpop.WhoAmI()}, nil
 	}

--- a/forward/request_sender.go
+++ b/forward/request_sender.go
@@ -127,7 +127,7 @@ func (s *requestSender) MakeCall(ctx context.Context, res *[]byte) <-chan error 
 			return
 		}
 
-		_, arg3, _, err := raw.WriteArgs(call, []byte{0, 0}, s.request)
+		_, arg3, _, err := raw.WriteArgs(call, nil, s.request)
 		if err != nil {
 			errC <- err
 			return


### PR DESCRIPTION
Pings that should be forwarded where causing timeouts. When waiting long enough it responded with a JSON parse error.

Cause was 0x0000 in the header of the forwarded request which was not parseable.
