### PR TITLE
Use Fingerprint32 over Hash32.

### DIFF
--- a/hashring.go
+++ b/hashring.go
@@ -83,7 +83,7 @@ func (r *hashRing) ComputeChecksum() {
 	}
 
 	old := r.servers.checksum
-	r.servers.checksum = farm.Hash32(buffer.Bytes())
+	r.servers.checksum = farm.Fingerprint32(buffer.Bytes())
 	r.ringpop.ringEvent(RingChecksumEvent{
 		OldChecksum: old,
 		NewChecksum: r.servers.checksum,

--- a/ringpop.go
+++ b/ringpop.go
@@ -151,7 +151,7 @@ func NewRingpop(app, address string, channel *tchannel.Channel, opts *Options) *
 	})
 	ringpop.node.RegisterListener(ringpop)
 
-	ringpop.ring = newHashRing(ringpop, farm.Hash32, opts.ReplicaPoints)
+	ringpop.ring = newHashRing(ringpop, farm.Fingerprint32, opts.ReplicaPoints)
 
 	ringpop.stats.hostport = genStatsHostport(ringpop.address)
 	ringpop.stats.prefix = fmt.Sprintf("ringpop.%s", ringpop.stats.hostport)

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -69,7 +69,7 @@ func (m *memberlist) Checksum() uint32 {
 func (m *memberlist) ComputeChecksum() {
 	startTime := time.Now()
 	m.members.Lock()
-	checksum := farm.Hash32([]byte(m.GenChecksumString()))
+	checksum := farm.Fingerprint32([]byte(m.GenChecksumString()))
 	m.members.checksum = checksum
 	m.members.Unlock()
 	m.node.emit(ChecksumComputeEvent{


### PR DESCRIPTION
fingerprint is platform independent: https://github.com/lovell/farmhash#fingerprint.

Looks like TChannel ran into the same issue: https://github.com/uber/tchannel-node/commit/44a7edbb1facc9f53b29633820a4d7afbb03dc2d

/cc @uber/ringpop 
