### PR TITLE
Depend on tchannel.Registrar instead of SubChannel

### DIFF
--- a/forward/forwarder.go
+++ b/forward/forwarder.go
@@ -88,12 +88,12 @@ func (f *Forwarder) mergeDefaultOptions(opts *Options) *Options {
 // A Forwarder is used to forward requests to their destinations
 type Forwarder struct {
 	sender  Sender
-	channel *tchannel.SubChannel
+	channel tchannel.Registrar
 	logger  log.Logger
 }
 
 // NewForwarder returns a new forwarder
-func NewForwarder(s Sender, ch *tchannel.SubChannel, logger log.Logger) *Forwarder {
+func NewForwarder(s Sender, ch tchannel.Registrar, logger log.Logger) *Forwarder {
 	if logger == nil {
 		logger = log.NewLoggerFromLogrus(&logrus.Logger{
 			Out: ioutil.Discard,

--- a/forward/request_sender.go
+++ b/forward/request_sender.go
@@ -35,7 +35,7 @@ import (
 // lookup method
 type requestSender struct {
 	sender  Sender
-	channel *tchannel.SubChannel
+	channel tchannel.Registrar
 
 	request           []byte
 	destination       string
@@ -56,7 +56,7 @@ type requestSender struct {
 }
 
 // NewRequestSender returns a new request sender that can be used to forward a request to its destination
-func newRequestSender(sender Sender, channel *tchannel.SubChannel, request []byte, keys []string,
+func newRequestSender(sender Sender, channel tchannel.Registrar, request []byte, keys []string,
 	destination, service, endpoint string, format tchannel.Format, opts *Options) *requestSender {
 
 	return &requestSender{

--- a/replica/replicator.go
+++ b/replica/replicator.go
@@ -93,7 +93,7 @@ type callOptions struct {
 // ownership of some data.
 type Replicator struct {
 	sender    Sender
-	channel   *tchannel.SubChannel
+	channel   tchannel.Registrar
 	forwarder *forward.Forwarder
 	logger    log.Logger
 	defaults  *Options
@@ -126,7 +126,7 @@ func mergeDefaultOptions(opts *Options, def *Options) *Options {
 // NewReplicator returns a new Replicator instance that makes calls with the given
 // SubChannel to the service defined by SubChannel.GetServiceName(). The given n/w/r
 // values will be used as defaults for the replicator when none are provided
-func NewReplicator(s Sender, channel *tchannel.SubChannel, logger log.Logger,
+func NewReplicator(s Sender, channel tchannel.Registrar, logger log.Logger,
 	opts *Options) *Replicator {
 
 	if logger == nil {

--- a/ringpop.go
+++ b/ringpop.go
@@ -107,7 +107,7 @@ type Ringpop struct {
 		sync.RWMutex
 	}
 
-	channel   *tchannel.SubChannel
+	channel   tchannel.Registrar
 	node      *swim.Node
 	ring      *hashRing
 	forwarder *forward.Forwarder

--- a/swim/node.go
+++ b/swim/node.go
@@ -122,7 +122,7 @@ type Node struct {
 	bootstrapFile  string
 	bootstrapHosts map[string][]string
 
-	channel      *tchannel.SubChannel
+	channel      tchannel.Registrar
 	memberlist   *memberlist
 	memberiter   memberIter
 	disseminator *disseminator
@@ -147,7 +147,7 @@ type Node struct {
 }
 
 // NewNode returns a new SWIM node
-func NewNode(app, address string, channel *tchannel.SubChannel, opts *Options) *Node {
+func NewNode(app, address string, channel tchannel.Registrar, opts *Options) *Node {
 	// use defaults for options that are unspecified
 	opts = mergeDefaultOptions(opts)
 


### PR DESCRIPTION
Ringpop only needs the functionality of `tchannel.Registrar`; rather than depending on the concrete `*tchannel.SubChannel` type, let's explicitly use the provided interface.

Ringpop builds with this change, and test failures are identical to the failures present on master.

// fyi @prashantv
