### PR TITLE
Fix headers sent with forwarded requests

### DIFF
--- a/forward/request_sender.go
+++ b/forward/request_sender.go
@@ -127,7 +127,12 @@ func (s *requestSender) MakeCall(ctx context.Context, res *[]byte) <-chan error 
 			return
 		}
 
-		_, arg3, _, err := raw.WriteArgs(call, []byte{0, 0}, s.request)
+		var arg3 []byte
+		if s.format == tchannel.Thrift {
+			_, arg3, _, err = raw.WriteArgs(call, []byte{0, 0}, s.request)
+		} else {
+			_, arg3, _, err = raw.WriteArgs(call, nil, s.request)
+		}
 		if err != nil {
 			errC <- err
 			return

--- a/forward/request_sender.go
+++ b/forward/request_sender.go
@@ -127,7 +127,7 @@ func (s *requestSender) MakeCall(ctx context.Context, res *[]byte) <-chan error 
 			return
 		}
 
-		_, arg3, _, err := raw.WriteArgs(call, nil, s.request)
+		_, arg3, _, err := raw.WriteArgs(call, []byte{0, 0}, s.request)
 		if err != nil {
 			errC <- err
 			return


### PR DESCRIPTION
Per the [TChannel spec](https://github.com/uber/tchannel/blob/master/docs/thrift.md), the minimum header is 2 bytes. Without this change, forwarded requests always time out.