### PR TITLE
Add headers to forwarder and add test

### DIFF
--- a/forward/forwarder.go
+++ b/forward/forwarder.go
@@ -110,10 +110,10 @@ func NewForwarder(s Sender, ch tchannel.Registrar, logger log.Logger) *Forwarder
 // ForwardRequest forwards a request to the given service and endpoint returns the response.
 // Keys are used by the sender to lookup the destination on retry. If you have multiple keys
 // and their destinations diverge on a retry then the call is aborted.
-func (f *Forwarder) ForwardRequest(request []byte, destination, service, endpoint string,
+func (f *Forwarder) ForwardRequest(request, headers []byte, destination, service, endpoint string,
 	keys []string, format tchannel.Format, opts *Options) ([]byte, error) {
 
 	opts = f.mergeDefaultOptions(opts)
-	rs := newRequestSender(f.sender, f.channel, request, keys, destination, service, endpoint, format, opts)
+	rs := newRequestSender(f.sender, f.channel, request, headers, keys, destination, service, endpoint, format, opts)
 	return rs.Send()
 }

--- a/forward/request_sender.go
+++ b/forward/request_sender.go
@@ -38,6 +38,7 @@ type requestSender struct {
 	channel tchannel.Registrar
 
 	request           []byte
+	headers           []byte
 	destination       string
 	service, endpoint string
 	keys              []string
@@ -56,13 +57,14 @@ type requestSender struct {
 }
 
 // NewRequestSender returns a new request sender that can be used to forward a request to its destination
-func newRequestSender(sender Sender, channel tchannel.Registrar, request []byte, keys []string,
+func newRequestSender(sender Sender, channel tchannel.Registrar, request, headers []byte, keys []string,
 	destination, service, endpoint string, format tchannel.Format, opts *Options) *requestSender {
 
 	return &requestSender{
 		sender:         sender,
 		channel:        channel,
 		request:        request,
+		headers:        headers,
 		keys:           keys,
 		destination:    destination,
 		service:        service,
@@ -127,7 +129,7 @@ func (s *requestSender) MakeCall(ctx context.Context, res *[]byte) <-chan error 
 			return
 		}
 
-		_, arg3, _, err := raw.WriteArgs(call, nil, s.request)
+		_, arg3, _, err := raw.WriteArgs(call, s.headers, s.request)
 		if err != nil {
 			errC <- err
 			return

--- a/ringpop.go
+++ b/ringpop.go
@@ -390,7 +390,7 @@ func (rp *Ringpop) getStatKey(key string) string {
 // if it should be forwarded to a different node. If false is returned, forwarding
 // is taken care of internally by the method, and, if no error has occured, the
 // response is written in the provided response field.
-func (rp *Ringpop) HandleOrForward(key string, request []byte, response *[]byte, service, endpoint string,
+func (rp *Ringpop) HandleOrForward(key string, request, headers []byte, response *[]byte, service, endpoint string,
 	format tchannel.Format, opts *forward.Options) (bool, error) {
 
 	dest := rp.Lookup(key)
@@ -398,7 +398,7 @@ func (rp *Ringpop) HandleOrForward(key string, request []byte, response *[]byte,
 		return true, nil
 	}
 
-	res, err := rp.forwarder.ForwardRequest(request, dest, service, endpoint, []string{key}, format, opts)
+	res, err := rp.forwarder.ForwardRequest(request, headers, dest, service, endpoint, []string{key}, format, opts)
 	*response = res
 
 	return false, err


### PR DESCRIPTION
Short-term fix for #23

Since thrift/JSON require different headers, pass headers from the caller.