### PR TITLE
Disable TChannel retries and zipkin tracing for ringpop.

### DIFF
--- a/forward/request_sender.go
+++ b/forward/request_sender.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/context"
 
 	log "github.com/uber-common/bark"
+	"github.com/uber/ringpop-go/shared"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/raw"
 )
@@ -77,7 +78,7 @@ func newRequestSender(sender Sender, channel tchannel.Registrar, request []byte,
 }
 
 func (s *requestSender) Send() (res []byte, err error) {
-	ctx, cancel := tchannel.NewContext(s.timeout)
+	ctx, cancel := shared.NewTChannelContext(s.timeout)
 	defer cancel()
 
 	select {

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -1,0 +1,20 @@
+package shared
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/uber/tchannel-go"
+)
+
+var retryOptions = &tchannel.RetryOptions{
+	RetryOn: tchannel.RetryNever,
+}
+
+func NewTChannelContext(timeout time.Duration) (tchannel.ContextWithHeaders, context.CancelFunc) {
+	return tchannel.NewContextBuilder(timeout).
+		DisableTracing().
+		SetRetryOptions(retryOptions).
+		Build()
+}

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -3,9 +3,9 @@ package shared
 import (
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/uber/tchannel-go"
+
+	"golang.org/x/net/context"
 )
 
 var retryOptions = &tchannel.RetryOptions{

--- a/swim/join_sender.go
+++ b/swim/join_sender.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	log "github.com/uber-common/bark"
+	"github.com/uber/ringpop-go/shared"
 	"github.com/uber/ringpop-go/swim/util"
 	"github.com/uber/tchannel-go/json"
 )
@@ -300,7 +301,7 @@ func (j *joinSender) JoinGroup(nodesJoined []string) ([]string, []string) {
 	for _, node := range group {
 		wg.Add(1)
 		go func(n string) {
-			ctx, cancel := json.NewContext(j.timeout)
+			ctx, cancel := shared.NewTChannelContext(j.timeout)
 			defer cancel()
 
 			var res joinResponse

--- a/swim/ping_request_sender.go
+++ b/swim/ping_request_sender.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	log "github.com/uber-common/bark"
+	"github.com/uber/ringpop-go/shared"
 	"github.com/uber/tchannel-go/json"
 )
 
@@ -64,7 +65,7 @@ func (p *pingRequestSender) SendPingRequest() (*pingResponse, error) {
 		"target": p.target,
 	}).Debug("ping request send")
 
-	ctx, cancel := json.NewContext(p.timeout)
+	ctx, cancel := shared.NewTChannelContext(p.timeout)
 	defer cancel()
 
 	var res pingResponse

--- a/swim/ping_sender.go
+++ b/swim/ping_sender.go
@@ -26,6 +26,7 @@ import (
 
 	log "github.com/uber-common/bark"
 
+	"github.com/uber/ringpop-go/shared"
 	"github.com/uber/tchannel-go/json"
 )
 
@@ -56,7 +57,8 @@ func newPingSender(node *Node, target string, timeout time.Duration) *pingSender
 }
 
 func (p *pingSender) SendPing() (*ping, error) {
-	ctx, cancel := json.NewContext(p.timeout)
+	ctx, cancel := shared.NewTChannelContext(p.timeout)
+
 	defer cancel()
 
 	var res ping


### PR DESCRIPTION
Ringpop causes too many traces to be collected. This change is to disable tracing on internal ringpop calls. The biggest problems are tracing ping/pingreq, since these happen frequently from all machines to all machines.

cc @prashantv @uber/ringpop 