### PR TITLE
Expose a function on ringpop with all the current active members.

### DIFF
--- a/ringpop.go
+++ b/ringpop.go
@@ -362,8 +362,8 @@ func (rp *Ringpop) ringEvent(event interface{}) {
 	}
 }
 
-func (rp *Ringpop) GetMembers() []string {
-	return rp.node.GetMembers()
+func (rp *Ringpop) GetReachableMembers() []string {
+	return rp.node.GetReachableMembers()
 }
 
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =

--- a/ringpop.go
+++ b/ringpop.go
@@ -362,6 +362,17 @@ func (rp *Ringpop) ringEvent(event interface{}) {
 	}
 }
 
+func (rp *Ringpop) GetMembers() []string {
+	members := rp.node.MemberStats().Members
+	var addresses []string
+	for _, member := range members {
+		if member.Status == swim.Alive || member.Status == swim.Suspect {
+			addresses = append(addresses, member.Address)
+		}
+	}
+	return addresses
+}
+
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 //
 //	Stats

--- a/ringpop.go
+++ b/ringpop.go
@@ -363,14 +363,7 @@ func (rp *Ringpop) ringEvent(event interface{}) {
 }
 
 func (rp *Ringpop) GetMembers() []string {
-	members := rp.node.MemberStats().Members
-	var addresses []string
-	for _, member := range members {
-		if member.Status == swim.Alive || member.Status == swim.Suspect {
-			addresses = append(addresses, member.Address)
-		}
-	}
-	return addresses
+	return rp.node.GetMembers()
 }
 
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -324,3 +324,17 @@ func (m *memberlist) String() string {
 func (m *memberlist) Iter() *memberlistIter {
 	return newMemberlistIter(m)
 }
+
+func (m *memberlist) GetActiveMemberAddresses() []string {
+	var active []string
+
+	m.members.RLock()
+	for _, member := range m.members.list {
+		if member.Status == Alive || member.Status == Suspect {
+			active = append(active, member.Address)
+		}
+	}
+	m.members.RUnlock()
+
+	return active
+}

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -325,7 +325,7 @@ func (m *memberlist) Iter() *memberlistIter {
 	return newMemberlistIter(m)
 }
 
-func (m *memberlist) GetActiveMemberAddresses() []string {
+func (m *memberlist) GetReachableMembers() []string {
 	var active []string
 
 	m.members.RLock()

--- a/swim/memberlist_test.go
+++ b/swim/memberlist_test.go
@@ -21,6 +21,7 @@
 package swim
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -214,6 +215,25 @@ func (s *MemberlistTestSuite) TestRandomPingable() {
 
 	members = s.m.RandomPingableMembers(1, excluding)
 	s.Len(members, 1, "expected only one member")
+}
+
+func (s *MemberlistTestSuite) TestGetActiveMemberAddresses() {
+	nodeA := NewNode("test", "127.0.0.1:3001", nil, nil)
+	defer nodeA.Destroy()
+
+	nodeA.memberlist.MakeAlive("127.0.0.1:3001", s.incarnation)
+	nodeA.memberlist.MakeAlive("127.0.0.1:3002", s.incarnation)
+	nodeA.memberlist.MakeSuspect("127.0.0.1:3003", s.incarnation)
+	nodeA.memberlist.MakeFaulty("127.0.0.1:3004", s.incarnation)
+
+	activeMembers := nodeA.memberlist.GetActiveMemberAddresses()
+	sort.Strings(activeMembers)
+
+	s.Equal([]string{
+		"127.0.0.1:3001",
+		"127.0.0.1:3002",
+		"127.0.0.1:3003",
+	}, activeMembers, "Expected a list of 3 specific nodes")
 }
 
 func TestMemberlistTestSuite(t *testing.T) {

--- a/swim/memberlist_test.go
+++ b/swim/memberlist_test.go
@@ -217,7 +217,7 @@ func (s *MemberlistTestSuite) TestRandomPingable() {
 	s.Len(members, 1, "expected only one member")
 }
 
-func (s *MemberlistTestSuite) TestGetActiveMemberAddresses() {
+func (s *MemberlistTestSuite) TestGetReachableMembers() {
 	nodeA := NewNode("test", "127.0.0.1:3001", nil, nil)
 	defer nodeA.Destroy()
 
@@ -226,7 +226,7 @@ func (s *MemberlistTestSuite) TestGetActiveMemberAddresses() {
 	nodeA.memberlist.MakeSuspect("127.0.0.1:3003", s.incarnation)
 	nodeA.memberlist.MakeFaulty("127.0.0.1:3004", s.incarnation)
 
-	activeMembers := nodeA.memberlist.GetActiveMemberAddresses()
+	activeMembers := nodeA.memberlist.GetReachableMembers()
 	sort.Strings(activeMembers)
 
 	s.Equal([]string{

--- a/swim/node.go
+++ b/swim/node.go
@@ -512,12 +512,5 @@ func (n *Node) pingNextMember() {
 }
 
 func (n *Node) GetMembers() []string {
-	var addresses []string
-	for i := 0; i < n.memberlist.NumMembers(); i++ {
-		member := n.memberlist.MemberAt(i)
-		if member.Status == Alive || member.Status == Suspect {
-			addresses = append(addresses, member.Address)
-		}
-	}
-	return addresses
+	return n.memberlist.GetActiveMemberAddresses()
 }

--- a/swim/node.go
+++ b/swim/node.go
@@ -510,3 +510,14 @@ func (n *Node) pingNextMember() {
 		"numErrors": len(errs),
 	}).Warn("ping request inconclusive due to errors")
 }
+
+func (n *Node) GetMembers() []string {
+	var addresses []string
+	for i := 0; i < n.memberlist.NumMembers(); i++ {
+		member := n.memberlist.MemberAt(i)
+		if member.Status == Alive || member.Status == Suspect {
+			addresses = append(addresses, member.Address)
+		}
+	}
+	return addresses
+}

--- a/swim/node.go
+++ b/swim/node.go
@@ -511,6 +511,6 @@ func (n *Node) pingNextMember() {
 	}).Warn("ping request inconclusive due to errors")
 }
 
-func (n *Node) GetMembers() []string {
-	return n.memberlist.GetActiveMemberAddresses()
+func (n *Node) GetReachableMembers() []string {
+	return n.memberlist.GetReachableMembers()
 }


### PR DESCRIPTION
Users that want to get a list of all their active members should be able to get a slice of all those members.

A use case for this is if the user wants to do a manual fanout to all running instances.

cc @uber/ringpop 