### PR TITLE
Add Ringpop.Ready() method

### DIFF
--- a/ringpop.go
+++ b/ringpop.go
@@ -230,6 +230,12 @@ func (rp *Ringpop) Bootstrap(opts *BootstrapOptions) ([]string, error) {
 	return joined, nil
 }
 
+// Ready returns whether or not ringpop is bootstrapped and should receive
+// requests
+func (rp *Ringpop) Ready() bool {
+	return rp.node.Ready()
+}
+
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 //
 //	SWIM Events

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -139,6 +139,22 @@ func (s *RingpopTestSuite) TestHandleEvents() {
 	s.Equal(11, listener.EventCount(), "expected 11 total events to be recorded")
 }
 
+func (s *RingpopTestSuite) TestRingpopReady() {
+	s.False(s.ringpop.Ready())
+	// Create single node cluster.
+	s.ringpop.Bootstrap(&BootstrapOptions{
+		swim.BootstrapOptions{
+			Hosts: []string{"127.0.0.1:3001"},
+		},
+	})
+	s.True(s.ringpop.Ready())
+}
+
+func (s *RingpopTestSuite) TestRingpopNotReady() {
+	// Ringpop should not be ready until bootstrapped
+	s.False(s.ringpop.Ready())
+}
+
 func TestRingpopTestSuite(t *testing.T) {
 	suite.Run(t, new(RingpopTestSuite))
 }


### PR DESCRIPTION
Returns whether or not Ringpop is bootstrapped and thus ready to receive
requests. This is analogous to the IsReady flag in ringpop-node.