### PR TITLE
Change options pattern for Ringpop constructor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,18 @@
-testpop:	clean
-	godep go build scripts/testpop/testpop.go
+.PHONY: clean testpop mocks out
+
+out:	testpop
 
 clean:
 	rm -f testpop
 
-.PHONY: clean testpop
+clean-mocks:
+	rm -f test/mocks/*.go
+
+mocks:
+	test/gen-mocks
+
+test: mocks
+	go test ./...
+
+testpop:	clean
+	godep go build scripts/testpop/testpop.go

--- a/README.md
+++ b/README.md
@@ -1,15 +1,31 @@
-# ringpop-go
+ringpop-go
+==========
+
 Ringpop is a library that brings cooperation and coordination to distributed
 applications. It maintains a consistent hash ring on top of a membership
 protocol and provides request forwarding as a routing convenience. It can be
 used to shard your application in a way that's scalable and fault tolerant.
 
-# Installation
-To install Ringpop:
+Getting started
+---------------
+
+To install ringpop-go:
 
 ```
 go get github.com/uber/ringpop-go
 ```
 
-# Documentation
-Interested in where to go from here? Read the docs at [ringpop.readthedocs.org](https://ringpop.readthedocs.org)
+Developing
+----------
+
+Run the tests by doing:
+
+```
+make test
+```
+
+Documentation
+--------------
+
+Interested in where to go from here? Read the docs at
+[ringpop.readthedocs.org](https://ringpop.readthedocs.org)

--- a/examples/ping-ring/.gitignore
+++ b/examples/ping-ring/.gitignore
@@ -1,0 +1,1 @@
+ping-ring

--- a/examples/ping-ring/main.go
+++ b/examples/ping-ring/main.go
@@ -95,12 +95,19 @@ func main() {
 
 	logger := log.StandardLogger()
 
+	rp, err := ringpop.New("ping-app",
+		ringpop.Channel(ch),
+		ringpop.Identity(*hostport),
+		ringpop.Logger(bark.NewLoggerFromLogrus(logger)),
+	)
+	if err != nil {
+		log.Fatalf("Unable to create Ringpop: %v", err)
+	}
+
 	worker := &worker{
 		channel: ch,
-		ringpop: ringpop.NewRingpop("ping-app", *hostport, ch, &ringpop.Options{
-			Logger: bark.NewLoggerFromLogrus(logger),
-		}),
-		logger: logger,
+		ringpop: rp,
+		logger:  logger,
 	}
 
 	if err := worker.RegisterPong(); err != nil {

--- a/examples/pingpong/.gitignore
+++ b/examples/pingpong/.gitignore
@@ -1,0 +1,1 @@
+pingpong

--- a/examples/pingpong/pingpong.go
+++ b/examples/pingpong/pingpong.go
@@ -45,11 +45,18 @@ type worker struct {
 func newWorker(address string, channel *tchannel.Channel) *worker {
 	logger := bark.NewLoggerFromLogrus(logrus.StandardLogger())
 
+	rp, err := ringpop.New("pingpong",
+		ringpop.Channel(channel),
+		ringpop.Identity(address),
+		ringpop.Logger(logger),
+	)
+	if err != nil {
+		log.Fatalf("Unable to create Ringpop: %v", err)
+	}
+
 	return &worker{
 		address: address,
-		ringpop: ringpop.NewRingpop("pingpong", address, channel, &ringpop.Options{
-			Logger: logger,
-		}),
+		ringpop: rp,
 	}
 }
 

--- a/forward/forwarder.go
+++ b/forward/forwarder.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	log "github.com/uber-common/bark"
+	"github.com/uber/ringpop-go/shared"
 	"github.com/uber/ringpop-go/swim/util"
 	"github.com/uber/tchannel-go"
 )
@@ -88,12 +89,12 @@ func (f *Forwarder) mergeDefaultOptions(opts *Options) *Options {
 // A Forwarder is used to forward requests to their destinations
 type Forwarder struct {
 	sender  Sender
-	channel tchannel.Registrar
+	channel shared.SubChannel
 	logger  log.Logger
 }
 
 // NewForwarder returns a new forwarder
-func NewForwarder(s Sender, ch tchannel.Registrar, logger log.Logger) *Forwarder {
+func NewForwarder(s Sender, ch shared.SubChannel, logger log.Logger) *Forwarder {
 	if logger == nil {
 		logger = log.NewLoggerFromLogrus(&logrus.Logger{
 			Out: ioutil.Discard,

--- a/forward/request_sender.go
+++ b/forward/request_sender.go
@@ -36,7 +36,7 @@ import (
 // lookup method
 type requestSender struct {
 	sender  Sender
-	channel tchannel.Registrar
+	channel shared.SubChannel
 
 	request           []byte
 	destination       string
@@ -57,7 +57,7 @@ type requestSender struct {
 }
 
 // NewRequestSender returns a new request sender that can be used to forward a request to its destination
-func newRequestSender(sender Sender, channel tchannel.Registrar, request []byte, keys []string,
+func newRequestSender(sender Sender, channel shared.SubChannel, request []byte, keys []string,
 	destination, service, endpoint string, format tchannel.Format, opts *Options) *requestSender {
 
 	return &requestSender{

--- a/hashring.go
+++ b/hashring.go
@@ -31,6 +31,10 @@ import (
 	"github.com/dgryski/go-farm"
 )
 
+type HashRingConfiguration struct {
+	ReplicaPoints int
+}
+
 type hashRing struct {
 	ringpop       *Ringpop
 	hashfunc      func([]byte) uint32

--- a/hashring_test.go
+++ b/hashring_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/uber/tchannel-go"
 )
 
 type RingTestSuite struct {
@@ -34,7 +35,14 @@ type RingTestSuite struct {
 }
 
 func (s *RingTestSuite) SetupTest() {
-	s.ringpop = NewRingpop("test", "127.0.0.1:3001", nil, nil)
+	ch, err := tchannel.NewChannel("test", nil)
+	s.Require().NoError(err, "channel must create successfully")
+
+	s.ringpop, err = New("test", Identity("127.0.0.1:3001"), Channel(ch))
+
+	s.NoError(err)
+	s.NotNil(s.ringpop)
+
 	s.ring = s.ringpop.ring
 }
 

--- a/options.go
+++ b/options.go
@@ -35,8 +35,6 @@ type Configuration struct {
 	// that App is taken as an argument of the Ringpop constructor and not a
 	// configuration option. This is to prevent accidental misconfiguration.
 	App string
-
-	ReplicaPoints int
 }
 
 // "Options" are modifier functions that configure/modify a real Ringpop

--- a/options.go
+++ b/options.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ringpop
+
+import (
+	"errors"
+	"io/ioutil"
+
+	"github.com/Sirupsen/logrus"
+	log "github.com/uber-common/bark"
+	"github.com/uber/ringpop-go/shared"
+)
+
+type Configuration struct {
+	// App is the name used to uniquely identify members of the same ring.
+	// Members will only talk to other members with the same app name. Note
+	// that App is taken as an argument of the Ringpop constructor and not a
+	// configuration option. This is to prevent accidental misconfiguration.
+	App string
+
+	ReplicaPoints int
+}
+
+// "Options" are modifier functions that configure/modify a real Ringpop
+// object.
+//
+// There are typically two types of runtime options you can provide: flags
+// (functions that modify the object) and value options (functions the accept
+// user-specific arguments and then return a function that modifies the
+// object).
+//
+// For more information, see:
+// http://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html
+//
+type Option func(*Ringpop) error
+
+// applyOptions applies runtime configuration options to the specified Ringpop
+// instance.
+func applyOptions(r *Ringpop, opts []Option) error {
+	for _, option := range opts {
+		err := option(r)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkOptions checks that the Ringpop instance has been properly configured
+// with all the required options.
+func checkOptions(rp *Ringpop) []error {
+	errs := []error{}
+	if rp.channel == nil {
+		errs = append(errs, errors.New("Channel is required"))
+	}
+	if rp.identityResolver == nil {
+		errs = append(errs, errors.New("Identity resolver is nil"))
+	}
+	return errs
+}
+
+// Runtime options
+
+func Channel(ch shared.TChannel) Option {
+	return func(r *Ringpop) error {
+		r.channel = ch
+		return nil
+	}
+}
+
+func HashRingConfig(c *HashRingConfiguration) Option {
+	return func(r *Ringpop) error {
+		r.configHashRing = c
+		return nil
+	}
+}
+
+func Logger(l log.Logger) Option {
+	return func(r *Ringpop) error {
+		r.logger = l
+		r.log = l
+		return nil
+	}
+}
+
+func Statter(s log.StatsReporter) Option {
+	return func(r *Ringpop) error {
+		r.statter = s
+		return nil
+	}
+}
+
+// IdentityResolver is a function that returns the listen interface/port
+// that Ringpop should identify as.
+type IdentityResolver func() (string, error)
+
+func IdentityResolverFunc(resolver IdentityResolver) Option {
+	return func(r *Ringpop) error {
+		r.identityResolver = resolver
+		return nil
+	}
+}
+
+// Identity specifies a static hostport string as Ringpop's identity.
+func Identity(hostport string) Option {
+	return IdentityResolverFunc(func() (string, error) {
+		return hostport, nil
+	})
+}
+
+// Default options
+
+// defaultIdentityResolver sets the default identityResolver
+func defaultIdentityResolver(r *Ringpop) error {
+	r.identityResolver = r.channelIdentityResolver
+	return nil
+}
+
+// defaultLogger is the default logger that is used for Ringpop if one is not
+// provided by the user.
+func defaultLogger(r *Ringpop) error {
+	return Logger(log.NewLoggerFromLogrus(&logrus.Logger{
+		Out: ioutil.Discard,
+	}))(r)
+}
+
+func defaultStatter(r *Ringpop) error {
+	return Statter(noopStatsReporter{})(r)
+}
+
+func defaultHashRingOptions(r *Ringpop) error {
+	return HashRingConfig(defaultHashRingConfiguration)(r)
+}
+
+// defaultOptions are the default options/values when Ringpop is created. They
+// can be overridden at runtime.
+var defaultOptions = []Option{
+	defaultIdentityResolver,
+	defaultLogger,
+	defaultStatter,
+	defaultHashRingOptions,
+}
+
+var defaultHashRingConfiguration = &HashRingConfiguration{
+	ReplicaPoints: 100,
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ringpop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber/ringpop-go/test/mocks"
+	"github.com/uber/tchannel-go"
+)
+
+type RingpopOptionsTestSuite struct {
+	suite.Suite
+	ringpop *Ringpop
+	channel *tchannel.Channel
+}
+
+func (s *RingpopOptionsTestSuite) SetupTest() {
+
+	ch, err := tchannel.NewChannel("test", nil)
+	s.Require().NoError(err, "Channel creation failed")
+
+	s.channel = ch
+}
+
+// TestDefaults tests that the default options are applied to a Ringpop
+// instance during construction, when none are specified by the user.
+func (s *RingpopOptionsTestSuite) TestDefaults() {
+
+	rp, err := New("test", Channel(s.channel))
+	s.Require().NotNil(rp)
+	s.Require().NoError(err)
+
+	// Check that these defaults are not nil
+	s.NotNil(rp.logger)
+	s.NotNil(rp.statter)
+	s.Equal(defaultHashRingConfiguration, rp.configHashRing)
+
+	// Create a ringpop instance to manually apply these options and verify
+	// them against the constructed instance. TODO: use a mocked Ringpop
+	// instead.
+	testRingpop := &Ringpop{}
+	defaultStatter(testRingpop)
+	defaultLogger(testRingpop)
+	defaultHashRingOptions(testRingpop)
+
+	s.Equal(testRingpop.logger, rp.logger)
+	s.Equal(testRingpop.statter, rp.statter)
+	s.Equal(testRingpop.configHashRing, rp.configHashRing)
+}
+
+// TestDefaultIdentityResolver tests that Ringpop gets the identity from the
+// TChannel object by default.
+func (s *RingpopOptionsTestSuite) TestDefaultIdentityResolver() {
+
+	// Start listening, to get a hostport assigned
+	s.channel.ListenAndServe("127.0.0.1:0")
+	hostport := s.channel.PeerInfo().HostPort
+
+	// Create the Ringpop instance with this channel
+	rp, err := New("test", Channel(s.channel))
+	s.Require().NotNil(rp)
+	s.Require().NoError(err)
+
+	identity, err := rp.identity()
+
+	// Check that the identity of Ringpop matches the TChannel hostport
+	s.Equal(hostport, identity)
+	s.NoError(err)
+}
+
+// TestChannelRequired tests that Ringpop creation fails if a Channel is not
+// passed.
+func (s *RingpopOptionsTestSuite) TestChannelRequired() {
+	rp, err := New("test")
+	s.Nil(rp)
+	s.Error(err)
+}
+
+// TestLogger tests that the logger that's passed in gets applied correctly to
+// the Ringpop instance.
+func (s *RingpopOptionsTestSuite) TestLogger() {
+
+	mockLogger := &mocks.Logger{}
+	mockLogger.On("WithField", mock.Anything, mock.Anything).Return(mockLogger)
+
+	rp, err := New("test", Channel(s.channel), Logger(mockLogger))
+	s.Require().NotNil(rp)
+	s.Require().NoError(err)
+
+	s.Exactly(mockLogger, rp.logger)
+}
+
+// TestStatter tests that the statter that's passed in gets applied correctly
+// to the Ringpop instance.
+func (s *RingpopOptionsTestSuite) TestStatter() {
+
+	mockStatter := &mocks.StatsReporter{}
+
+	rp, err := New("test", Channel(s.channel), Statter(mockStatter))
+	s.Require().NotNil(rp)
+	s.Require().NoError(err)
+
+	s.Exactly(mockStatter, rp.statter)
+}
+
+// TestHashRingConfig tests that the HashRing config that's passed in is
+// applied and used correctly.
+func (s *RingpopOptionsTestSuite) TestHashRingConfig() {
+
+	rp, err := New("test", Channel(s.channel), HashRingConfig(
+		&HashRingConfiguration{
+			ReplicaPoints: 42,
+		}),
+	)
+	s.Require().NotNil(rp)
+	s.Require().NoError(err)
+
+	s.Equal(rp.configHashRing.ReplicaPoints, 42)
+}
+
+// TestIdentityResolverFunc tests the func that's passed gets applied to the
+// Ringpop instance.
+func (s *RingpopOptionsTestSuite) TestIdentityResolverFunc() {
+
+	f := func() (string, error) {
+		return "127.0.0.1:3001", nil
+	}
+
+	rp, err := New("test", Channel(s.channel), IdentityResolverFunc(f))
+	s.Require().NotNil(rp)
+	s.Require().NoError(err)
+
+	identity, err := rp.identityResolver()
+
+	s.Equal("127.0.0.1:3001", identity)
+	s.NoError(err)
+}
+
+// TestMissingIdentityResolver tests the Ringpop constructor throws an error
+// if the user sets the identity resolver to nil
+func (s *RingpopOptionsTestSuite) TestMissingIdentityResolver() {
+
+	rp, err := New("test", Channel(s.channel), IdentityResolverFunc(nil))
+	s.Nil(rp)
+	s.Error(err)
+}
+
+func TestRingpopOptionsTestSuite(t *testing.T) {
+	suite.Run(t, new(RingpopOptionsTestSuite))
+}

--- a/replica/replicator.go
+++ b/replica/replicator.go
@@ -31,7 +31,7 @@ import (
 	log "github.com/uber-common/bark"
 	"github.com/uber/ringpop-go/forward"
 	"github.com/uber/ringpop-go/replica/util"
-	"github.com/uber/tchannel-go"
+	"github.com/uber/ringpop-go/shared"
 )
 
 // FanoutMode defines how a replicator should fanout it's requests
@@ -93,7 +93,7 @@ type callOptions struct {
 // ownership of some data.
 type Replicator struct {
 	sender    Sender
-	channel   tchannel.Registrar
+	channel   shared.SubChannel
 	forwarder *forward.Forwarder
 	logger    log.Logger
 	defaults  *Options
@@ -126,7 +126,7 @@ func mergeDefaultOptions(opts *Options, def *Options) *Options {
 // NewReplicator returns a new Replicator instance that makes calls with the given
 // SubChannel to the service defined by SubChannel.GetServiceName(). The given n/w/r
 // values will be used as defaults for the replicator when none are provided
-func NewReplicator(s Sender, channel tchannel.Registrar, logger log.Logger,
+func NewReplicator(s Sender, channel shared.SubChannel, logger log.Logger,
 	opts *Options) *Replicator {
 
 	if logger == nil {

--- a/replica/replicator_test.go
+++ b/replica/replicator_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/ringpop-go/forward"
+	"github.com/uber/ringpop-go/shared"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/json"
 	"golang.org/x/net/context"
@@ -113,7 +114,7 @@ func (s *ReplicatorTestSuite) ResetLookupN() {
 	s.sender.lookupN = lookupN
 }
 
-func (s *ReplicatorTestSuite) RegisterHandler(ch tchannel.Registrar, address string) {
+func (s *ReplicatorTestSuite) RegisterHandler(ch shared.SubChannel, address string) {
 	handler := map[string]interface{}{
 		"/ping": func(ctx json.Context, ping *Ping) (*Pong, error) {
 			s.Equal(ping.From, "127.0.0.1:3001")

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -39,20 +39,12 @@ func (s *RingpopTestSuite) SetupTest() {
 	ch, err := tchannel.NewChannel("test", nil)
 	s.Require().NoError(err, "channel must create successfully")
 	s.channel = ch
-	s.ringpop = NewRingpop("test", "127.0.0.1:3001", ch, nil)
+	s.ringpop, err = New("test", Identity("127.0.0.1:3001"), Channel(ch))
+	s.Require().NoError(err, "Ringpop must create successfully")
 }
 
 func (s *RingpopTestSuite) TearDownTest() {
 	s.ringpop.Destroy()
-}
-
-func (s *RingpopTestSuite) TestMergeDefault() {
-	s.ringpop = NewRingpop("test", "127.0.0.1:3001", s.channel, &Options{})
-
-	def := defaultOptions()
-
-	s.EqualValues(s.ringpop.logger, def.Logger, "expected default logger to be used")
-	s.EqualValues(s.ringpop.statter, def.Statter, "expected default stats to be used")
 }
 
 func (s *RingpopTestSuite) TestHandlesMemberlistChangeEvent() {

--- a/scripts/testpop/.gitignore
+++ b/scripts/testpop/.gitignore
@@ -1,0 +1,1 @@
+testpop

--- a/scripts/testpop/testpop.go
+++ b/scripts/testpop/testpop.go
@@ -54,9 +54,11 @@ func main() {
 	if *verbose {
 		logger.Level = log.DebugLevel
 	}
-	rp := ringpop.NewRingpop("ringpop", *hostport, ch, &ringpop.Options{
-		Logger: bark.NewLoggerFromLogrus(logger),
-	})
+	rp, _ := ringpop.New("ringpop",
+		ringpop.Channel(ch),
+		ringpop.Identity(*hostport),
+		ringpop.Logger(bark.NewLoggerFromLogrus(logger)),
+	)
 
 	if err := ch.ListenAndServe(rp.WhoAmI()); err != nil {
 		log.Fatalf("could not listen on %s: %v", rp.WhoAmI(), err)

--- a/shared/interfaces.go
+++ b/shared/interfaces.go
@@ -1,0 +1,13 @@
+package shared
+
+import "github.com/uber/tchannel-go"
+
+type TChannel interface {
+	tchannel.Registrar
+	PeerInfo() tchannel.LocalPeerInfo
+	GetSubChannel(string, ...tchannel.SubChannelOption) *tchannel.SubChannel
+}
+
+type SubChannel interface {
+	tchannel.Registrar
+}

--- a/swim/node.go
+++ b/swim/node.go
@@ -29,8 +29,8 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/rcrowley/go-metrics"
 	log "github.com/uber-common/bark"
+	"github.com/uber/ringpop-go/shared"
 	"github.com/uber/ringpop-go/swim/util"
-	"github.com/uber/tchannel-go"
 )
 
 // Options to create a SWIM with
@@ -122,7 +122,7 @@ type Node struct {
 	bootstrapFile  string
 	bootstrapHosts map[string][]string
 
-	channel      tchannel.Registrar
+	channel      shared.SubChannel
 	memberlist   *memberlist
 	memberiter   memberIter
 	disseminator *disseminator
@@ -147,7 +147,7 @@ type Node struct {
 }
 
 // NewNode returns a new SWIM node
-func NewNode(app, address string, channel tchannel.Registrar, opts *Options) *Node {
+func NewNode(app, address string, channel shared.SubChannel, opts *Options) *Node {
 	// use defaults for options that are unspecified
 	opts = mergeDefaultOptions(opts)
 

--- a/test/gen-mocks
+++ b/test/gen-mocks
@@ -1,0 +1,9 @@
+#!/bin/sh -x
+#
+# Generate mocks for ringpop and subpackages.
+#
+mock_directory="${0%/*}/mocks"
+
+# Generate mocks for bark
+mockery -case=underscore -dir "$GOPATH"/src/github.com/uber-common/bark -recursive -output "$mock_directory" -name Logger
+mockery -case=underscore -dir "$GOPATH"/src/github.com/uber-common/bark -recursive -output "$mock_directory" -name StatsReporter

--- a/test/mocks/README
+++ b/test/mocks/README
@@ -1,0 +1,1 @@
+Files in this directory have been automatically generated using mockery.

--- a/test/mocks/logger.go
+++ b/test/mocks/logger.go
@@ -1,0 +1,81 @@
+package mocks
+
+import "github.com/uber-common/bark"
+import "github.com/stretchr/testify/mock"
+
+type Logger struct {
+	mock.Mock
+}
+
+func (_m *Logger) Debug(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Debugf(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) Info(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Infof(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) Warn(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Warnf(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) Error(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Errorf(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) Fatal(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Fatalf(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) Panic(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Panicf(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) WithField(key string, value interface{}) bark.Logger {
+	ret := _m.Called(key, value)
+
+	var r0 bark.Logger
+	if rf, ok := ret.Get(0).(func(string, interface{}) bark.Logger); ok {
+		r0 = rf(key, value)
+	} else {
+		r0 = ret.Get(0).(bark.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) WithFields(keyValues bark.LogFields) bark.Logger {
+	ret := _m.Called(keyValues)
+
+	var r0 bark.Logger
+	if rf, ok := ret.Get(0).(func(bark.LogFields) bark.Logger); ok {
+		r0 = rf(keyValues)
+	} else {
+		r0 = ret.Get(0).(bark.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) Fields() bark.Fields {
+	ret := _m.Called()
+
+	var r0 bark.Fields
+	if rf, ok := ret.Get(0).(func() bark.Fields); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bark.Fields)
+	}
+
+	return r0
+}

--- a/test/mocks/stats_reporter.go
+++ b/test/mocks/stats_reporter.go
@@ -1,0 +1,20 @@
+package mocks
+
+import "github.com/uber-common/bark"
+import "github.com/stretchr/testify/mock"
+
+import "time"
+
+type StatsReporter struct {
+	mock.Mock
+}
+
+func (_m *StatsReporter) IncCounter(name string, tags bark.Tags, value int64) {
+	_m.Called(name, tags, value)
+}
+func (_m *StatsReporter) UpdateGauge(name string, tags bark.Tags, value int64) {
+	_m.Called(name, tags, value)
+}
+func (_m *StatsReporter) RecordTimer(name string, tags bark.Tags, d time.Duration) {
+	_m.Called(name, tags, d)
+}

--- a/test_utils.go
+++ b/test_utils.go
@@ -26,11 +26,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/uber-common/bark"
 	"github.com/uber/ringpop-go/swim"
 	"github.com/uber/ringpop-go/swim/util"
-	"github.com/uber/tchannel-go"
 )
 
 // fake stats
@@ -74,14 +72,10 @@ func (d *dummyListener) HandleEvent(event interface{}) {
 }
 
 func testPop(t *testing.T, hostport string) (*Ringpop, func()) {
-	ch, err := tchannel.NewChannel("test-app", nil)
-	require.NoError(t, err, "cannot have error when creating channel")
-
-	ringpop := NewRingpop("test-app", hostport, ch, nil)
+	ringpop, _ := New("test-app")
 
 	destroy := func() {
 		ringpop.Destroy()
-		ch.Close()
 	}
 
 	return ringpop, destroy


### PR DESCRIPTION
Change options pattern for Ringpop constructor

This is a breaking change which makes future options changes easier.

Instead of taking constructor options as arguments (or in a struct) we
use a modifier pattern, where each option is a function which modifies
the object being created.

This allows certain options to be ... optional.

This change is to support a future change which will make the "address"
argument optional in the constructor.

Since this is a breaking change, we also take the opportunity to rename
the constructor to ringpop.New, which is more idiomatic.