### PR TITLE
Improvements to ringpop-go tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+go:
+  - 1.5
+script: make

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean-mocks:
 mocks:
 	test/gen-mocks
 
-test: mocks
+test:
 	go test ./...
 
 testpop:	clean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: clean testpop mocks out
+.PHONY: clean clean-mocks testpop mocks out test
 
-out:	testpop
+out:	test
 
 clean:
 	rm -f testpop

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Developing
 Run the tests by doing:
 
 ```
-make test
+make
 ```
 
 Documentation

--- a/events/events.go
+++ b/events/events.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package ringpop
+package events
 
 import "time"
 

--- a/hashring.go
+++ b/hashring.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/uber/ringpop-go/events"
 	"github.com/uber/ringpop-go/rbtree"
 
 	"github.com/dgryski/go-farm"
@@ -88,7 +89,7 @@ func (r *hashRing) ComputeChecksum() {
 
 	old := r.servers.checksum
 	r.servers.checksum = farm.Fingerprint32(buffer.Bytes())
-	r.ringpop.ringEvent(RingChecksumEvent{
+	r.ringpop.ringEvent(events.RingChecksumEvent{
 		OldChecksum: old,
 		NewChecksum: r.servers.checksum,
 	})
@@ -102,7 +103,7 @@ func (r *hashRing) AddServer(address string) {
 	}
 
 	r.AddReplicas(address)
-	r.ringpop.ringEvent(RingChangedEvent{ServersAdded: []string{address}})
+	r.ringpop.ringEvent(events.RingChangedEvent{ServersAdded: []string{address}})
 	r.ComputeChecksum()
 }
 
@@ -125,7 +126,7 @@ func (r *hashRing) RemoveServer(address string) {
 	}
 
 	r.RemoveReplicas(address)
-	r.ringpop.ringEvent(RingChangedEvent{ServersRemoved: []string{address}})
+	r.ringpop.ringEvent(events.RingChangedEvent{ServersRemoved: []string{address}})
 	r.ComputeChecksum()
 }
 
@@ -163,7 +164,7 @@ func (r *hashRing) AddRemoveServers(add []string, remove []string) bool {
 	changed = added || removed
 
 	if changed {
-		r.ringpop.ringEvent(RingChangedEvent{add, remove})
+		r.ringpop.ringEvent(events.RingChangedEvent{add, remove})
 		r.ComputeChecksum()
 	}
 

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -26,21 +26,27 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/ringpop-go/swim"
+	"github.com/uber/ringpop-go/test/mocks"
 	"github.com/uber/tchannel-go"
 )
 
 type RingpopTestSuite struct {
 	suite.Suite
-	ringpop *Ringpop
-	channel *tchannel.Channel
+	ringpop     *Ringpop
+	channel     *tchannel.Channel
+	mockRingpop *mocks.Ringpop
 }
 
 func (s *RingpopTestSuite) SetupTest() {
+
 	ch, err := tchannel.NewChannel("test", nil)
 	s.Require().NoError(err, "channel must create successfully")
 	s.channel = ch
+
 	s.ringpop, err = New("test", Identity("127.0.0.1:3001"), Channel(ch))
 	s.Require().NoError(err, "Ringpop must create successfully")
+
+	s.mockRingpop = &mocks.Ringpop{}
 }
 
 func (s *RingpopTestSuite) TearDownTest() {
@@ -134,10 +140,8 @@ func (s *RingpopTestSuite) TestHandleEvents() {
 func (s *RingpopTestSuite) TestRingpopReady() {
 	s.False(s.ringpop.Ready())
 	// Create single node cluster.
-	s.ringpop.Bootstrap(&BootstrapOptions{
-		swim.BootstrapOptions{
-			Hosts: []string{"127.0.0.1:3001"},
-		},
+	s.ringpop.Bootstrap(&swim.BootstrapOptions{
+		Hosts: []string{"127.0.0.1:3001"},
 	})
 	s.True(s.ringpop.Ready())
 }

--- a/test/gen-mocks
+++ b/test/gen-mocks
@@ -7,3 +7,10 @@ mock_directory="${0%/*}/mocks"
 # Generate mocks for bark
 mockery -case=underscore -dir "$GOPATH"/src/github.com/uber-common/bark -recursive -output "$mock_directory" -name Logger
 mockery -case=underscore -dir "$GOPATH"/src/github.com/uber-common/bark -recursive -output "$mock_directory" -name StatsReporter
+
+# Generate mock file for ringpop.Interface, but rename the mocked object to
+# mocks.Ringpop
+mockery -name Interface -print \
+    |sed 's/_m \*Interface/_m \*Ringpop/g' \
+    |sed 's/type Interface/type Ringpop/g' \
+    > "$mock_directory"/ringpop.go

--- a/test/gen-mocks
+++ b/test/gen-mocks
@@ -1,7 +1,9 @@
-#!/bin/sh -x
+#!/bin/bash -x
 #
 # Generate mocks for ringpop and subpackages.
 #
+set -eo pipefail
+
 mock_directory="${0%/*}/mocks"
 
 # Generate mocks for bark

--- a/test/mocks/ringpop.go
+++ b/test/mocks/ringpop.go
@@ -1,0 +1,247 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+import "time"
+
+import "github.com/uber/ringpop-go/events"
+import "github.com/uber/ringpop-go/forward"
+
+import "github.com/uber/ringpop-go/swim"
+import "github.com/uber/tchannel-go"
+
+type Ringpop struct {
+	mock.Mock
+}
+
+func (_m *Ringpop) Destroy() {
+	_m.Called()
+}
+func (_m *Ringpop) Destroyed() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+func (_m *Ringpop) App() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+func (_m *Ringpop) WhoAmI() (string, error) {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Ringpop) Uptime() (time.Duration, error) {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Ringpop) RegisterListener(l events.EventListener) {
+	_m.Called(l)
+}
+func (_m *Ringpop) Bootstrap(opts *swim.BootstrapOptions) ([]string, error) {
+	ret := _m.Called(opts)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(*swim.BootstrapOptions) []string); ok {
+		r0 = rf(opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*swim.BootstrapOptions) error); ok {
+		r1 = rf(opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Ringpop) HandleEvent(event interface{}) {
+	_m.Called(event)
+}
+func (_m *Ringpop) Checksum() (uint32, error) {
+	ret := _m.Called()
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Ringpop) Lookup(key string) (string, error) {
+	ret := _m.Called(key)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(key)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(key)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Ringpop) LookupN(key string, n int) ([]string, error) {
+	ret := _m.Called(key, n)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(string, int) []string); ok {
+		r0 = rf(key, n)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, int) error); ok {
+		r1 = rf(key, n)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Ringpop) GetReachableMembers() ([]string, error) {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Ringpop) CountReachableMembers() (int, error) {
+	ret := _m.Called()
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Ringpop) HandleOrForward(key string, request []byte, response *[]byte, service string, endpoint string, format tchannel.Format, opts *forward.Options) (bool, error) {
+	ret := _m.Called(key, request, response, service, endpoint, format, opts)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, []byte, *[]byte, string, string, tchannel.Format, *forward.Options) bool); ok {
+		r0 = rf(key, request, response, service, endpoint, format, opts)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, []byte, *[]byte, string, string, tchannel.Format, *forward.Options) error); ok {
+		r1 = rf(key, request, response, service, endpoint, format, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *Ringpop) Forward(dest string, keys []string, request []byte, service string, endpoint string, format tchannel.Format, opts *forward.Options) ([]byte, error) {
+	ret := _m.Called(dest, keys, request, service, endpoint, format, opts)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(string, []string, []byte, string, string, tchannel.Format, *forward.Options) []byte); ok {
+		r0 = rf(dest, keys, request, service, endpoint, format, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, []string, []byte, string, string, tchannel.Format, *forward.Options) error); ok {
+		r1 = rf(dest, keys, request, service, endpoint, format, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}


### PR DESCRIPTION
This adds `ringpop.Interface` and a mock for Ringpop.

To support this:
* Events moved to their own package to avoid circular dependencies.
* Signature of Bootstrap changed to accept `swim.BootstrapOptions`.

@uber/ringpop 