### PR TITLE
The ringpop.Interface was not in sync with the implementation.

### DIFF
--- a/examples/ping-ring/main.go
+++ b/examples/ping-ring/main.go
@@ -27,6 +27,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/uber-common/bark"
 	"github.com/uber/ringpop-go"
+	"github.com/uber/ringpop-go/swim"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/json"
 	"golang.org/x/net/context"
@@ -118,7 +119,7 @@ func main() {
 		log.Fatalf("could not listen on given hostport: %v", err)
 	}
 
-	opts := new(ringpop.BootstrapOptions)
+	opts := new(swim.BootstrapOptions)
 	opts.File = *hostfile
 
 	if _, err := worker.ringpop.Bootstrap(opts); err != nil {

--- a/examples/pingpong/pingpong.go
+++ b/examples/pingpong/pingpong.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber-common/bark"
 	"github.com/uber/ringpop-go"
 	"github.com/uber/ringpop-go/examples/pingpong/gen-go/pingpong"
+	"github.com/uber/ringpop-go/swim"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/thrift"
 )
@@ -106,7 +107,7 @@ func main() {
 		log.Fatalf("could not listen on hostport: %v", err)
 	}
 
-	bsopts := new(ringpop.BootstrapOptions)
+	bsopts := new(swim.BootstrapOptions)
 	bsopts.File = *hostfile
 	bsopts.Stopped = true
 	if _, err := worker.ringpop.Bootstrap(bsopts); err != nil {

--- a/ringpop.go
+++ b/ringpop.go
@@ -60,16 +60,14 @@ type Interface interface {
 	Destroy()
 	Destroyed() bool
 	App() string
-	WhoAmI() (string, error)
-	Uptime() (time.Duration, error)
+	WhoAmI() string
+	Uptime() time.Duration
 	RegisterListener(l events.EventListener)
 	Bootstrap(opts *swim.BootstrapOptions) ([]string, error)
 	HandleEvent(event interface{})
-	Checksum() (uint32, error)
-	Lookup(key string) (string, error)
-	LookupN(key string, n int) ([]string, error)
-	GetReachableMembers() ([]string, error)
-	CountReachableMembers() (int, error)
+	Checksum() uint32
+	Lookup(key string) string
+	LookupN(key string, n int) []string
 
 	HandleOrForward(key string, request []byte, response *[]byte, service, endpoint string, format tchannel.Format, opts *forward.Options) (bool, error)
 	Forward(dest string, keys []string, request []byte, service, endpoint string, format tchannel.Format, opts *forward.Options) ([]byte, error)

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -53,6 +53,13 @@ func (s *RingpopTestSuite) TearDownTest() {
 	s.ringpop.Destroy()
 }
 
+func (s *RingpopTestSuite) TestCanAssignRingpopToRingpopInterface() {
+	var ri Interface
+	ri = s.ringpop
+
+	s.Assert().Equal(ri, s.ringpop, "ringpop in the interface is not equal to ringpop")
+}
+
 func (s *RingpopTestSuite) TestHandlesMemberlistChangeEvent() {
 	s.ringpop.HandleEvent(swim.MemberlistChangesAppliedEvent{
 		Changes: genChanges(genAddresses(1, 1, 10), swim.Alive),

--- a/scripts/testpop/testpop.go
+++ b/scripts/testpop/testpop.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/uber-common/bark"
 	"github.com/uber/ringpop-go"
+	"github.com/uber/ringpop-go/swim"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/uber/tchannel-go"
@@ -64,7 +65,7 @@ func main() {
 		log.Fatalf("could not listen on %s: %v", rp.WhoAmI(), err)
 	}
 
-	opts := &ringpop.BootstrapOptions{}
+	opts := &swim.BootstrapOptions{}
 	opts.File = *hostfile
 
 	_, err = rp.Bootstrap(opts)

--- a/test/mocks/ringpop.go
+++ b/test/mocks/ringpop.go
@@ -41,7 +41,7 @@ func (_m *Ringpop) App() string {
 
 	return r0
 }
-func (_m *Ringpop) WhoAmI() (string, error) {
+func (_m *Ringpop) WhoAmI() string {
 	ret := _m.Called()
 
 	var r0 string
@@ -51,16 +51,9 @@ func (_m *Ringpop) WhoAmI() (string, error) {
 		r0 = ret.Get(0).(string)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
-func (_m *Ringpop) Uptime() (time.Duration, error) {
+func (_m *Ringpop) Uptime() time.Duration {
 	ret := _m.Called()
 
 	var r0 time.Duration
@@ -70,14 +63,7 @@ func (_m *Ringpop) Uptime() (time.Duration, error) {
 		r0 = ret.Get(0).(time.Duration)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 func (_m *Ringpop) RegisterListener(l events.EventListener) {
 	_m.Called(l)
@@ -106,7 +92,7 @@ func (_m *Ringpop) Bootstrap(opts *swim.BootstrapOptions) ([]string, error) {
 func (_m *Ringpop) HandleEvent(event interface{}) {
 	_m.Called(event)
 }
-func (_m *Ringpop) Checksum() (uint32, error) {
+func (_m *Ringpop) Checksum() uint32 {
 	ret := _m.Called()
 
 	var r0 uint32
@@ -116,16 +102,9 @@ func (_m *Ringpop) Checksum() (uint32, error) {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
-func (_m *Ringpop) Lookup(key string) (string, error) {
+func (_m *Ringpop) Lookup(key string) string {
 	ret := _m.Called(key)
 
 	var r0 string
@@ -135,16 +114,9 @@ func (_m *Ringpop) Lookup(key string) (string, error) {
 		r0 = ret.Get(0).(string)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(key)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
-func (_m *Ringpop) LookupN(key string, n int) ([]string, error) {
+func (_m *Ringpop) LookupN(key string, n int) []string {
 	ret := _m.Called(key, n)
 
 	var r0 []string
@@ -156,54 +128,7 @@ func (_m *Ringpop) LookupN(key string, n int) ([]string, error) {
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string, int) error); ok {
-		r1 = rf(key, n)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-func (_m *Ringpop) GetReachableMembers() ([]string, error) {
-	ret := _m.Called()
-
-	var r0 []string
-	if rf, ok := ret.Get(0).(func() []string); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-func (_m *Ringpop) CountReachableMembers() (int, error) {
-	ret := _m.Called()
-
-	var r0 int
-	if rf, ok := ret.Get(0).(func() int); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 func (_m *Ringpop) HandleOrForward(key string, request []byte, response *[]byte, service string, endpoint string, format tchannel.Format, opts *forward.Options) (bool, error) {
 	ret := _m.Called(key, request, response, service, endpoint, format, opts)


### PR DESCRIPTION
@dansimau I updated the interface to have the same signature as Ringpop, added a test to make sure you can assign a Ringpop instance to its interface. And as a bonus, updated the examples with the `swim.Bootstrap` change.