### PR TITLE
Improve HashRing API

### DIFF
--- a/ringpop.go
+++ b/ringpop.go
@@ -86,7 +86,7 @@ type Ringpop struct {
 	channel    shared.TChannel
 	subChannel shared.SubChannel
 	node       *swim.Node
-	ring       *hashRing
+	ring       HashRing
 	forwarder  *forward.Forwarder
 
 	listeners []events.EventListener


### PR DESCRIPTION
This work stemmed from me trying to wrie a benchmark for Ringpop's hash ring lookup. There I noticed the HashRing implementation exporting too much of itself and tests digging into its internals. What I wound up with was this:

* Reduction of HashRing public API
* Defining its interface, located in internal/native, which uses Go's internal package feature (I _think_ it's useful to do it this way, but not entirely sure).
* Improving tests so that they treat HashRing more like a blackbox.

Check it out.

@uber/ringpop 