### PR TITLE
Ring package

### DIFF
--- a/hash_ring_configuration.go
+++ b/hash_ring_configuration.go
@@ -18,18 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package events
+package ringpop
 
-import "time"
-
-// An EventListener handles events given to it by the Ringpop, as well as forwarded events from
-// the SWIM node contained by the ringpop. HandleEvent should be thread safe.
-type EventListener interface {
-	HandleEvent(event interface{})
-}
-
-// A LookupEvent is sent when a lookup is performed on the Ringpop's ring
-type LookupEvent struct {
-	Key      string
-	Duration time.Duration
+type HashRingConfiguration struct {
+	ReplicaPoints int
 }

--- a/internal/native/event_emitter.go
+++ b/internal/native/event_emitter.go
@@ -17,19 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+package native
 
-package events
-
-import "time"
-
-// An EventListener handles events given to it by the Ringpop, as well as forwarded events from
-// the SWIM node contained by the ringpop. HandleEvent should be thread safe.
-type EventListener interface {
-	HandleEvent(event interface{})
-}
-
-// A LookupEvent is sent when a lookup is performed on the Ringpop's ring
-type LookupEvent struct {
-	Key      string
-	Duration time.Duration
+type EventEmitter interface {
+    RegisterListener(EventListener)
 }

--- a/internal/native/event_listener.go
+++ b/internal/native/event_listener.go
@@ -17,19 +17,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+package native
 
-package events
-
-import "time"
-
-// An EventListener handles events given to it by the Ringpop, as well as forwarded events from
-// the SWIM node contained by the ringpop. HandleEvent should be thread safe.
-type EventListener interface {
-	HandleEvent(event interface{})
-}
-
-// A LookupEvent is sent when a lookup is performed on the Ringpop's ring
-type LookupEvent struct {
-	Key      string
-	Duration time.Duration
-}
+type EventListener func(interface{})

--- a/ring/events.go
+++ b/ring/events.go
@@ -17,19 +17,17 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+package ring
 
-package events
-
-import "time"
-
-// An EventListener handles events given to it by the Ringpop, as well as forwarded events from
-// the SWIM node contained by the ringpop. HandleEvent should be thread safe.
-type EventListener interface {
-	HandleEvent(event interface{})
+// A RingChangedEvent is sent when servers are added and/or removed from the ring
+type RingChangedEvent struct {
+	ServersAdded   []string
+	ServersRemoved []string
 }
 
-// A LookupEvent is sent when a lookup is performed on the Ringpop's ring
-type LookupEvent struct {
-	Key      string
-	Duration time.Duration
+// RingChecksumEvent is sent when a server is removed or added and a new checksum
+// for the ring is calculated
+type RingChecksumEvent struct {
+	OldChecksum uint32
+	NewChecksum uint32
 }

--- a/ring/hashring_test.go
+++ b/ring/hashring_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package ringpop
+package ring_test
 
 import (
 	"fmt"

--- a/ring/iter.go
+++ b/ring/iter.go
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 // Package rbtree provides an implementation of a Red Black Tree.
-package rbtree
+package ring
 
 //Iter returns an iterator starting at the leftmost node in the tree
 func (t *RBTree) Iter() *RBIter {

--- a/ring/iter_test.go
+++ b/ring/iter_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package rbtree
+package ring_test
 
 import (
 	"testing"

--- a/ring/rbtree.go
+++ b/ring/rbtree.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package rbtree
+package ring
 
 // TODO: change RBNode.val from int to int64?
 

--- a/ring/rbtree_test.go
+++ b/ring/rbtree_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package rbtree
+package ring_test
 
 import (
 	"errors"

--- a/ringpop.go
+++ b/ringpop.go
@@ -49,6 +49,8 @@ import (
 	log "github.com/uber-common/bark"
 	"github.com/uber/ringpop-go/events"
 	"github.com/uber/ringpop-go/forward"
+	"github.com/uber/ringpop-go/internal/native"
+	"github.com/uber/ringpop-go/ring"
 	"github.com/uber/ringpop-go/shared"
 	"github.com/uber/ringpop-go/swim"
 	"github.com/uber/tchannel-go"
@@ -175,7 +177,10 @@ func (rp *Ringpop) init() error {
 	})
 	rp.node.RegisterListener(rp)
 
-	rp.ring = newHashRing(rp, farm.Fingerprint32, rp.configHashRing.ReplicaPoints)
+	var hashRing native.HashRing
+	hashRing = ring.New(farm.Fingerprint32, rp.configHashRing.ReplicaPoints)
+	hashRing.RegisterListener(rp.onRingEvent)
+	rp.ring = hashRing
 
 	rp.stats.hostport = genStatsHostport(address)
 	rp.stats.prefix = fmt.Sprintf("ringpop.%s", rp.stats.hostport)
@@ -438,14 +443,14 @@ func (rp *Ringpop) LookupN(key string, n int) ([]string, error) {
 	return rp.ring.LookupN(key, n), nil
 }
 
-func (rp *Ringpop) ringEvent(e interface{}) {
+func (rp *Ringpop) onRingEvent(e interface{}) {
 	rp.emit(e)
 
 	switch e := e.(type) {
-	case events.RingChecksumEvent:
+	case ring.RingChecksumEvent:
 		rp.statter.IncCounter(rp.getStatKey("ring.checksum-computed"), nil, 1)
 
-	case events.RingChangedEvent:
+	case ring.RingChangedEvent:
 		added := int64(len(e.ServersAdded))
 		removed := int64(len(e.ServersRemoved))
 		rp.statter.IncCounter(rp.getStatKey("ring.server-added"), nil, added)


### PR DESCRIPTION
This PR does a couple of things all related to moving the hash ring implementation into its own package:

* The rbtree package has been folded into it since the red-black tree, at a higher-level, is more just an implementation detail of the ring itself
* Removes the dependency the ring had on Ringpop. Now it is standalone and able to fire its events as an `EventEmitter` rather than a thing that depends on Ringpop to do so for it.
* Removes the Ring* events out of the global events package and into an `events.go` source file that is part of the ring package itself. 

Test will come...

@uber/ringpop 