### PR TITLE
Add lazy initialization

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,5 @@
+package ringpop
+
+import "errors"
+
+var ErrNotBootstrapped = errors.New("ringpop is not bootstrapped")

--- a/forward/forwarder.go
+++ b/forward/forwarder.go
@@ -36,10 +36,10 @@ import (
 // the server returned by Lookup(key)
 type Sender interface {
 	// WhoAmI should return the address of the local sender
-	WhoAmI() string
+	WhoAmI() (string, error)
 
 	// Lookup should return the server the request belongs to
-	Lookup(string) string
+	Lookup(string) (string, error)
 }
 
 // Options for the creation of a forwarder

--- a/forward/request_sender.go
+++ b/forward/request_sender.go
@@ -91,8 +91,10 @@ func (s *requestSender) Send() (res []byte, err error) {
 			return s.ScheduleRetry()
 		}
 
+		identity, _ := s.sender.WhoAmI()
+
 		s.logger.WithFields(log.Fields{
-			"local":       s.sender.WhoAmI(),
+			"local":       identity,
 			"destination": s.destination,
 			"service":     s.service,
 			"endpoint":    s.endpoint,
@@ -101,8 +103,11 @@ func (s *requestSender) Send() (res []byte, err error) {
 		return nil, errors.New("max retries exceeded")
 
 	case <-ctx.Done(): // request timed out
+
+		identity, _ := s.sender.WhoAmI()
+
 		s.logger.WithFields(log.Fields{
-			"local":       s.sender.WhoAmI(),
+			"local":       identity,
 			"destination": s.destination,
 			"service":     s.service,
 			"endpoint":    s.endpoint,
@@ -183,7 +188,11 @@ func (s *requestSender) RerouteRetry(destination string) ([]byte, error) {
 
 func (s *requestSender) LookupKeys(keys []string) (dests []string) {
 	for _, key := range keys {
-		dests = append(dests, s.sender.Lookup(key))
+		dest, err := s.sender.Lookup(key)
+		if err != nil {
+			continue
+		}
+		dests = append(dests, dest)
 	}
 
 	return dests

--- a/handlers.go
+++ b/handlers.go
@@ -37,7 +37,7 @@ func (rp *Ringpop) registerHandlers() error {
 		"/admin/lookup": rp.adminLookupHandler,
 	}
 
-	return json.Register(rp.channel, handlers, func(ctx context.Context, err error) {
+	return json.Register(rp.subChannel, handlers, func(ctx context.Context, err error) {
 		rp.log.WithField("error", err).Info("error occured")
 	})
 }
@@ -59,7 +59,11 @@ type lookupResponse struct {
 }
 
 func (rp *Ringpop) adminLookupHandler(ctx json.Context, req *lookupRequest) (*lookupResponse, error) {
-	return &lookupResponse{Dest: rp.Lookup(req.Key)}, nil
+	dest, err := rp.Lookup(req.Key)
+	if err != nil {
+		return nil, err
+	}
+	return &lookupResponse{Dest: dest}, nil
 }
 
 func (rp *Ringpop) adminReloadHandler(ctx json.Context, req *Arg) (*Arg, error) {

--- a/hashring_test.go
+++ b/hashring_test.go
@@ -39,6 +39,7 @@ func (s *RingTestSuite) SetupTest() {
 	s.Require().NoError(err, "channel must create successfully")
 
 	s.ringpop, err = New("test", Identity("127.0.0.1:3001"), Channel(ch))
+	s.ringpop.init()
 
 	s.NoError(err)
 	s.NotNil(s.ringpop)

--- a/options_test.go
+++ b/options_test.go
@@ -36,7 +36,6 @@ type RingpopOptionsTestSuite struct {
 }
 
 func (s *RingpopOptionsTestSuite) SetupTest() {
-
 	ch, err := tchannel.NewChannel("test", nil)
 	s.Require().NoError(err, "Channel creation failed")
 
@@ -46,7 +45,6 @@ func (s *RingpopOptionsTestSuite) SetupTest() {
 // TestDefaults tests that the default options are applied to a Ringpop
 // instance during construction, when none are specified by the user.
 func (s *RingpopOptionsTestSuite) TestDefaults() {
-
 	rp, err := New("test", Channel(s.channel))
 	s.Require().NotNil(rp)
 	s.Require().NoError(err)
@@ -72,7 +70,6 @@ func (s *RingpopOptionsTestSuite) TestDefaults() {
 // TestDefaultIdentityResolver tests that Ringpop gets the identity from the
 // TChannel object by default.
 func (s *RingpopOptionsTestSuite) TestDefaultIdentityResolver() {
-
 	// Start listening, to get a hostport assigned
 	s.channel.ListenAndServe("127.0.0.1:0")
 	hostport := s.channel.PeerInfo().HostPort
@@ -100,7 +97,6 @@ func (s *RingpopOptionsTestSuite) TestChannelRequired() {
 // TestLogger tests that the logger that's passed in gets applied correctly to
 // the Ringpop instance.
 func (s *RingpopOptionsTestSuite) TestLogger() {
-
 	mockLogger := &mocks.Logger{}
 	mockLogger.On("WithField", mock.Anything, mock.Anything).Return(mockLogger)
 
@@ -114,7 +110,6 @@ func (s *RingpopOptionsTestSuite) TestLogger() {
 // TestStatter tests that the statter that's passed in gets applied correctly
 // to the Ringpop instance.
 func (s *RingpopOptionsTestSuite) TestStatter() {
-
 	mockStatter := &mocks.StatsReporter{}
 
 	rp, err := New("test", Channel(s.channel), Statter(mockStatter))
@@ -127,7 +122,6 @@ func (s *RingpopOptionsTestSuite) TestStatter() {
 // TestHashRingConfig tests that the HashRing config that's passed in is
 // applied and used correctly.
 func (s *RingpopOptionsTestSuite) TestHashRingConfig() {
-
 	rp, err := New("test", Channel(s.channel), HashRingConfig(
 		&HashRingConfiguration{
 			ReplicaPoints: 42,
@@ -142,7 +136,6 @@ func (s *RingpopOptionsTestSuite) TestHashRingConfig() {
 // TestIdentityResolverFunc tests the func that's passed gets applied to the
 // Ringpop instance.
 func (s *RingpopOptionsTestSuite) TestIdentityResolverFunc() {
-
 	f := func() (string, error) {
 		return "127.0.0.1:3001", nil
 	}
@@ -160,7 +153,6 @@ func (s *RingpopOptionsTestSuite) TestIdentityResolverFunc() {
 // TestMissingIdentityResolver tests the Ringpop constructor throws an error
 // if the user sets the identity resolver to nil
 func (s *RingpopOptionsTestSuite) TestMissingIdentityResolver() {
-
 	rp, err := New("test", Channel(s.channel), IdentityResolverFunc(nil))
 	s.Nil(rp)
 	s.Error(err)

--- a/ringpop.go
+++ b/ringpop.go
@@ -128,7 +128,6 @@ const (
 
 // New returns a new Ringpop instance!
 func New(app string, opts ...Option) (*Ringpop, error) {
-
 	var err error
 
 	ringpop := &Ringpop{
@@ -159,7 +158,6 @@ func New(app string, opts ...Option) (*Ringpop, error) {
 
 // init configures a Ringpop instance and makes it ready to do comms.
 func (rp *Ringpop) init() error {
-
 	if rp.channel == nil {
 		return errors.New("Missing channel")
 	}
@@ -212,7 +210,6 @@ func (rp *Ringpop) channelIdentityResolver() (string, error) {
 
 // Destroy Ringpop
 func (rp *Ringpop) Destroy() {
-
 	if rp.node != nil {
 		rp.node.Destroy()
 	}
@@ -282,7 +279,6 @@ func (rp *Ringpop) setState(s state) {
 
 // Bootstrap starts the Ringpop
 func (rp *Ringpop) Bootstrap(opts *swim.BootstrapOptions) ([]string, error) {
-
 	if rp.getState() < initialized {
 		err := rp.init()
 		if err != nil {
@@ -415,7 +411,6 @@ func (rp *Ringpop) Checksum() (uint32, error) {
 // for the specified key. It returns an error if the Ringpop instance is not
 // yet initialised/bootstrapped.
 func (rp *Ringpop) Lookup(key string) (string, error) {
-
 	if !rp.Ready() {
 		return "", ErrNotBootstrapped
 	}

--- a/ringpop.go
+++ b/ringpop.go
@@ -58,16 +58,15 @@ import (
 // use.
 type Interface interface {
 	Destroy()
-	Destroyed() bool
 	App() string
-	WhoAmI() string
-	Uptime() time.Duration
+	WhoAmI() (string, error)
+	Uptime() (time.Duration, error)
 	RegisterListener(l events.EventListener)
 	Bootstrap(opts *swim.BootstrapOptions) ([]string, error)
 	HandleEvent(event interface{})
-	Checksum() uint32
-	Lookup(key string) string
-	LookupN(key string, n int) []string
+	Checksum() (uint32, error)
+	Lookup(key string) (string, error)
+	LookupN(key string, n int) ([]string, error)
 
 	HandleOrForward(key string, request []byte, response *[]byte, service, endpoint string, format tchannel.Format, opts *forward.Options) (bool, error)
 	Forward(dest string, keys []string, request []byte, service, endpoint string, format tchannel.Format, opts *forward.Options) ([]byte, error)
@@ -81,10 +80,8 @@ type Ringpop struct {
 
 	identityResolver IdentityResolver
 
-	state struct {
-		read, destroyed bool
-		sync.RWMutex
-	}
+	state      state
+	stateMutex sync.RWMutex
 
 	channel    shared.TChannel
 	subChannel shared.SubChannel
@@ -108,6 +105,26 @@ type Ringpop struct {
 
 	startTime time.Time
 }
+
+// state represents the internal state of a Ringpop instance.
+type state uint
+
+const (
+	// created means the Ringpop instance has been created but the swim node,
+	// stats and hasring haven't been set up. The listen address has not been
+	// resolved yet either.
+	created state = iota
+	// initialized means the listen address has been resolved and the swim
+	// node, stats and hashring have been instantiated onto the Ringpop
+	// instance.
+	initialized
+	// ready means Bootstrap has been called, the ring has successfully
+	// bootstrapped and is now ready to receive requests.
+	ready
+	// destroyed means the Ringpop instance has been shut down, is no longer
+	// ready for requests and cannot be revived.
+	destroyed
+)
 
 // New returns a new Ringpop instance!
 func New(app string, opts ...Option) (*Ringpop, error) {
@@ -135,10 +152,7 @@ func New(app string, opts ...Option) (*Ringpop, error) {
 		return nil, fmt.Errorf("%v", errs)
 	}
 
-	err = ringpop.init()
-	if err != nil {
-		return nil, err
-	}
+	ringpop.setState(created)
 
 	return ringpop, nil
 }
@@ -171,6 +185,8 @@ func (rp *Ringpop) init() error {
 
 	rp.forwarder = forward.NewForwarder(rp, rp.subChannel, rp.logger)
 
+	rp.setState(initialized)
+
 	return nil
 }
 
@@ -184,25 +200,29 @@ func (rp *Ringpop) identity() (string, error) {
 // TChannel object on the Ringpop instance.
 func (rp *Ringpop) channelIdentityResolver() (string, error) {
 	hostport := rp.channel.PeerInfo().HostPort
+	// Check that TChannel is listening. By default, TChannel listens on an
+	// ephemeral host/port. The real port is then assigned by the OS when
+	// ListenAndServe is called. If the hostport is 0.0.0.0:0, it means
+	// TChannel is not yet listening and the hostport cannot be resolved.
+	if hostport == "0.0.0.0:0" {
+		return "", fmt.Errorf("unable to resolve valid listen address (TChannel hostport is %s)", hostport)
+	}
 	return hostport, nil
 }
 
 // Destroy Ringpop
 func (rp *Ringpop) Destroy() {
-	rp.node.Destroy()
 
-	rp.state.Lock()
-	rp.state.destroyed = true
-	rp.state.Unlock()
+	if rp.node != nil {
+		rp.node.Destroy()
+	}
+
+	rp.setState(destroyed)
 }
 
-// Destroyed returns
-func (rp *Ringpop) Destroyed() bool {
-	rp.state.Lock()
-	destroyed := rp.state.destroyed
-	rp.state.Unlock()
-
-	return destroyed
+// destroyed returns
+func (rp *Ringpop) destroyed() bool {
+	return rp.getState() == destroyed
 }
 
 // App returns the app the ringpop belongs to
@@ -210,15 +230,21 @@ func (rp *Ringpop) App() string {
 	return rp.config.App
 }
 
-// WhoAmI returns the local address of the Ringpop node
-func (rp *Ringpop) WhoAmI() string {
-	address, _ := rp.identity()
-	return address
+// WhoAmI returns the address of the current/local Ringpop node. It returns an
+// error if Ringpop is not yet initialised/bootstrapped.
+func (rp *Ringpop) WhoAmI() (string, error) {
+	if !rp.Ready() {
+		return "", ErrNotBootstrapped
+	}
+	return rp.identity()
 }
 
 // Uptime returns the amount of time that the ringpop has been running for
-func (rp *Ringpop) Uptime() time.Duration {
-	return time.Now().Sub(rp.startTime)
+func (rp *Ringpop) Uptime() (time.Duration, error) {
+	if !rp.Ready() {
+		return 0, ErrNotBootstrapped
+	}
+	return time.Now().Sub(rp.startTime), nil
 }
 
 func (rp *Ringpop) emit(event interface{}) {
@@ -233,6 +259,21 @@ func (rp *Ringpop) RegisterListener(l events.EventListener) {
 	rp.listeners = append(rp.listeners, l)
 }
 
+// getState gets the state of the current Ringpop instance.
+func (rp *Ringpop) getState() state {
+	rp.stateMutex.RLock()
+	r := rp.state
+	rp.stateMutex.RUnlock()
+	return r
+}
+
+// setState sets the state of the current Ringpop instance.
+func (rp *Ringpop) setState(s state) {
+	rp.stateMutex.Lock()
+	rp.state = s
+	rp.stateMutex.Unlock()
+}
+
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 //
 //	Bootstrap
@@ -241,11 +282,22 @@ func (rp *Ringpop) RegisterListener(l events.EventListener) {
 
 // Bootstrap starts the Ringpop
 func (rp *Ringpop) Bootstrap(opts *swim.BootstrapOptions) ([]string, error) {
+
+	if rp.getState() < initialized {
+		err := rp.init()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	joined, err := rp.node.Bootstrap(opts)
 	if err != nil {
 		rp.log.WithField("error", err).Info("bootstrap failed")
+		rp.setState(initialized)
 		return nil, err
 	}
+
+	rp.setState(ready)
 
 	rp.log.WithField("joined", joined).Info("bootstrap complete")
 	return joined, nil
@@ -254,6 +306,9 @@ func (rp *Ringpop) Bootstrap(opts *swim.BootstrapOptions) ([]string, error) {
 // Ready returns whether or not ringpop is bootstrapped and should receive
 // requests
 func (rp *Ringpop) Ready() bool {
+	if rp.getState() != ready {
+		return false
+	}
 	return rp.node.Ready()
 }
 
@@ -349,29 +404,43 @@ func (rp *Ringpop) handleChanges(changes []swim.Change) {
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
 // Checksum returns the checksum of the ringpop's hashring
-func (rp *Ringpop) Checksum() uint32 {
-	return rp.ring.Checksum()
+func (rp *Ringpop) Checksum() (uint32, error) {
+	if !rp.Ready() {
+		return 0, ErrNotBootstrapped
+	}
+	return rp.ring.Checksum(), nil
 }
 
-// Lookup hashes a key to a server in the ring
-func (rp *Ringpop) Lookup(key string) string {
+// Lookup returns the address of the server in the ring that is responsible
+// for the specified key. It returns an error if the Ringpop instance is not
+// yet initialised/bootstrapped.
+func (rp *Ringpop) Lookup(key string) (string, error) {
+
+	if !rp.Ready() {
+		return "", ErrNotBootstrapped
+	}
+
 	startTime := time.Now()
 
-	dest, ok := rp.ring.Lookup(key)
+	dest, success := rp.ring.Lookup(key)
 
 	rp.emit(events.LookupEvent{key, time.Now().Sub(startTime)})
 
-	if !ok {
-		rp.log.WithField("key", key).Warn("could not find destination for key")
-		return rp.WhoAmI()
+	if !success {
+		err := errors.New("could not find destination for key")
+		rp.log.WithField("key", key).Warn(err)
+		return "", err
 	}
 
-	return dest
+	return dest, nil
 }
 
 // LookupN hashes a key to N servers in the ring
-func (rp *Ringpop) LookupN(key string, n int) []string {
-	return rp.ring.LookupN(key, n)
+func (rp *Ringpop) LookupN(key string, n int) ([]string, error) {
+	if !rp.Ready() {
+		return nil, ErrNotBootstrapped
+	}
+	return rp.ring.LookupN(key, n), nil
 }
 
 func (rp *Ringpop) ringEvent(e interface{}) {
@@ -389,8 +458,11 @@ func (rp *Ringpop) ringEvent(e interface{}) {
 	}
 }
 
-func (rp *Ringpop) GetReachableMembers() []string {
-	return rp.node.GetReachableMembers()
+func (rp *Ringpop) GetReachableMembers() ([]string, error) {
+	if !rp.Ready() {
+		return nil, ErrNotBootstrapped
+	}
+	return rp.node.GetReachableMembers(), nil
 }
 
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
@@ -424,8 +496,21 @@ func (rp *Ringpop) getStatKey(key string) string {
 func (rp *Ringpop) HandleOrForward(key string, request []byte, response *[]byte, service, endpoint string,
 	format tchannel.Format, opts *forward.Options) (bool, error) {
 
-	dest := rp.Lookup(key)
-	if dest == rp.WhoAmI() {
+	if !rp.Ready() {
+		return false, ErrNotBootstrapped
+	}
+
+	dest, err := rp.Lookup(key)
+	if err != nil {
+		return false, err
+	}
+
+	identity, err := rp.WhoAmI()
+	if err != nil {
+		return false, err
+	}
+
+	if dest == identity {
 		return true, nil
 	}
 

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -37,19 +37,40 @@ type RingpopTestSuite struct {
 	mockRingpop *mocks.Ringpop
 }
 
+// createSingleNodeCluster is a helper function to create a single-node cluster
+// during the tests
+func createSingleNodeCluster(rp *Ringpop) error {
+
+	// We must resolve the identity in order to be able to Bootstrap with the
+	// correct options.
+	identity, err := rp.identity()
+	if err != nil {
+		return err
+	}
+
+	// Bootstrapping with a single host that matches the Ringpop instance's
+	// identity will created a single-node cluster.
+	_, err = rp.Bootstrap(&swim.BootstrapOptions{
+		Hosts: []string{identity},
+	})
+
+	return err
+}
+
 func (s *RingpopTestSuite) SetupTest() {
 
 	ch, err := tchannel.NewChannel("test", nil)
-	s.Require().NoError(err, "channel must create successfully")
+	s.NoError(err, "channel must create successfully")
 	s.channel = ch
 
 	s.ringpop, err = New("test", Identity("127.0.0.1:3001"), Channel(ch))
-	s.Require().NoError(err, "Ringpop must create successfully")
+	s.NoError(err, "Ringpop must create successfully")
 
 	s.mockRingpop = &mocks.Ringpop{}
 }
 
 func (s *RingpopTestSuite) TearDownTest() {
+	s.channel.Close()
 	s.ringpop.Destroy()
 }
 
@@ -61,6 +82,9 @@ func (s *RingpopTestSuite) TestCanAssignRingpopToRingpopInterface() {
 }
 
 func (s *RingpopTestSuite) TestHandlesMemberlistChangeEvent() {
+	// Fake bootstrap
+	s.ringpop.init()
+
 	s.ringpop.HandleEvent(swim.MemberlistChangesAppliedEvent{
 		Changes: genChanges(genAddresses(1, 1, 10), swim.Alive),
 	})
@@ -93,6 +117,9 @@ func (s *RingpopTestSuite) TestHandlesMemberlistChangeEvent() {
 }
 
 func (s *RingpopTestSuite) TestHandleEvents() {
+	// Fake bootstrap
+	s.ringpop.init()
+
 	stats := newDummyStats()
 	s.ringpop.statter = stats
 
@@ -156,6 +183,171 @@ func (s *RingpopTestSuite) TestRingpopReady() {
 func (s *RingpopTestSuite) TestRingpopNotReady() {
 	// Ringpop should not be ready until bootstrapped
 	s.False(s.ringpop.Ready())
+}
+
+// TestStateCreated tests that Ringpop is in a created state just after
+// instantiating.
+func (s *RingpopTestSuite) TestStateCreated() {
+	s.Equal(created, s.ringpop.getState())
+}
+
+// TestStateInitialized tests that Ringpop is in an initialized state after
+// a failed bootstrap attempt.
+func (s *RingpopTestSuite) TestStateInitialized() {
+
+	// Create channel and start listening so we can actually attempt to
+	// bootstrap
+	ch, _ := tchannel.NewChannel("test2", nil)
+	ch.ListenAndServe("127.0.0.1:0")
+	defer ch.Close()
+
+	rp, err := New("test2", Channel(ch))
+	s.NoError(err)
+	s.NotNil(rp)
+
+	// Bootstrap that will fail
+	_, err = rp.Bootstrap(&swim.BootstrapOptions{
+		Hosts: []string{
+			"127.0.0.1:9000",
+			"127.0.0.1:9001",
+		},
+		// A MaxJoinDuration of 1 millisecond should fail immediately
+		// without prolonging the test suite.
+		MaxJoinDuration: time.Millisecond,
+	})
+	s.Error(err)
+
+	s.Equal(initialized, rp.getState())
+}
+
+// TestStateReady tests that Ringpop is ready after successful bootstrapping.
+func (s *RingpopTestSuite) TestStateReady() {
+
+	// Bootstrap
+	createSingleNodeCluster(s.ringpop)
+
+	s.Equal(ready, s.ringpop.state)
+}
+
+// TestStateDestroyed tests that Ringpop is in a destroyed state after calling
+// Destroy().
+func (s *RingpopTestSuite) TestStateDestroyed() {
+
+	// Bootstrap
+	createSingleNodeCluster(s.ringpop)
+
+	// Destroy
+	s.ringpop.Destroy()
+	s.Equal(destroyed, s.ringpop.state)
+}
+
+// TestDestroyFromCreated tests that Destroy() can be called straight away.
+func (s *RingpopTestSuite) TestDestroyFromCreated() {
+	// Ringpop starts in the created state
+	s.Equal(created, s.ringpop.state)
+
+	// Should be destroyed straight away
+	s.ringpop.Destroy()
+	s.Equal(destroyed, s.ringpop.state)
+}
+
+// TestDestroyFromInitialized tests that Destroy() can be called from the
+// initialized state.
+func (s *RingpopTestSuite) TestDestroyFromInitialized() {
+	// Init
+	s.ringpop.init()
+	s.Equal(initialized, s.ringpop.state)
+
+	s.ringpop.Destroy()
+	s.Equal(destroyed, s.ringpop.state)
+}
+
+// TestDestroyIsIdempotent tests that Destroy() can be called multiple times.
+func (s *RingpopTestSuite) TestDestroyIsIdempotent() {
+
+	createSingleNodeCluster(s.ringpop)
+
+	s.ringpop.Destroy()
+	s.Equal(destroyed, s.ringpop.state)
+
+	// Can destroy again
+	s.ringpop.Destroy()
+	s.Equal(destroyed, s.ringpop.state)
+}
+
+// TestWhoAmI tests that WhoAmI only operates when the Ringpop instance is in
+// a ready state.
+func (s *RingpopTestSuite) TestWhoAmI() {
+
+	s.NotEqual(ready, s.ringpop.state)
+	identity, err := s.ringpop.WhoAmI()
+	s.Equal("", identity)
+	s.Error(err)
+
+	createSingleNodeCluster(s.ringpop)
+	s.Equal(ready, s.ringpop.state)
+	identity, err = s.ringpop.WhoAmI()
+	s.NoError(err)
+	s.Equal("127.0.0.1:3001", identity)
+}
+
+// TestUptime tests that Uptime only operates when the Ringpop instance is in
+// a ready state.
+func (s *RingpopTestSuite) TestUptime() {
+
+	s.NotEqual(ready, s.ringpop.state)
+	uptime, err := s.ringpop.Uptime()
+	s.Zero(uptime)
+	s.Error(err)
+
+	createSingleNodeCluster(s.ringpop)
+	s.Equal(ready, s.ringpop.state)
+	uptime, err = s.ringpop.Uptime()
+	s.NoError(err)
+	s.NotZero(uptime)
+}
+
+// TestChecksum tests that Checksum only operates when the Ringpop instance is in
+// a ready state.
+func (s *RingpopTestSuite) TestChecksum() {
+
+	s.NotEqual(ready, s.ringpop.state)
+	checksum, err := s.ringpop.Checksum()
+	s.Zero(checksum)
+	s.Error(err)
+
+	createSingleNodeCluster(s.ringpop)
+	s.Equal(ready, s.ringpop.state)
+	checksum, err = s.ringpop.Checksum()
+	s.NoError(err)
+	//s.NotZero(checksum)
+}
+
+// TestApp tests that App() returns the correct app name.
+func (s *RingpopTestSuite) TestApp() {
+	s.Equal("test", s.ringpop.App())
+}
+
+// TestLookupNotReady tests that Lookup fails when Ringpop is not ready.
+func (s *RingpopTestSuite) TestLookupNotReady() {
+	result, err := s.ringpop.Lookup("foo")
+	s.Error(err)
+	s.Empty(result)
+}
+
+// TestLookupNNotReady tests that LookupN fails when Ringpop is not ready.
+func (s *RingpopTestSuite) TestLookupNNotReady() {
+	result, err := s.ringpop.LookupN("foo", 3)
+	s.Error(err)
+	s.Nil(result)
+}
+
+// TestGetReachableMembersNotReady tests that GetReachableMembers fails when
+// Ringpop is not ready.
+func (s *RingpopTestSuite) TestGetReachableMembersNotReady() {
+	result, err := s.ringpop.GetReachableMembers()
+	s.Error(err)
+	s.Nil(result)
 }
 
 func TestRingpopTestSuite(t *testing.T) {

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -40,7 +40,6 @@ type RingpopTestSuite struct {
 // createSingleNodeCluster is a helper function to create a single-node cluster
 // during the tests
 func createSingleNodeCluster(rp *Ringpop) error {
-
 	// We must resolve the identity in order to be able to Bootstrap with the
 	// correct options.
 	identity, err := rp.identity()
@@ -194,7 +193,6 @@ func (s *RingpopTestSuite) TestStateCreated() {
 // TestStateInitialized tests that Ringpop is in an initialized state after
 // a failed bootstrap attempt.
 func (s *RingpopTestSuite) TestStateInitialized() {
-
 	// Create channel and start listening so we can actually attempt to
 	// bootstrap
 	ch, _ := tchannel.NewChannel("test2", nil)
@@ -222,7 +220,6 @@ func (s *RingpopTestSuite) TestStateInitialized() {
 
 // TestStateReady tests that Ringpop is ready after successful bootstrapping.
 func (s *RingpopTestSuite) TestStateReady() {
-
 	// Bootstrap
 	createSingleNodeCluster(s.ringpop)
 
@@ -232,7 +229,6 @@ func (s *RingpopTestSuite) TestStateReady() {
 // TestStateDestroyed tests that Ringpop is in a destroyed state after calling
 // Destroy().
 func (s *RingpopTestSuite) TestStateDestroyed() {
-
 	// Bootstrap
 	createSingleNodeCluster(s.ringpop)
 
@@ -264,7 +260,6 @@ func (s *RingpopTestSuite) TestDestroyFromInitialized() {
 
 // TestDestroyIsIdempotent tests that Destroy() can be called multiple times.
 func (s *RingpopTestSuite) TestDestroyIsIdempotent() {
-
 	createSingleNodeCluster(s.ringpop)
 
 	s.ringpop.Destroy()
@@ -278,7 +273,6 @@ func (s *RingpopTestSuite) TestDestroyIsIdempotent() {
 // TestWhoAmI tests that WhoAmI only operates when the Ringpop instance is in
 // a ready state.
 func (s *RingpopTestSuite) TestWhoAmI() {
-
 	s.NotEqual(ready, s.ringpop.state)
 	identity, err := s.ringpop.WhoAmI()
 	s.Equal("", identity)
@@ -294,7 +288,6 @@ func (s *RingpopTestSuite) TestWhoAmI() {
 // TestUptime tests that Uptime only operates when the Ringpop instance is in
 // a ready state.
 func (s *RingpopTestSuite) TestUptime() {
-
 	s.NotEqual(ready, s.ringpop.state)
 	uptime, err := s.ringpop.Uptime()
 	s.Zero(uptime)
@@ -310,7 +303,6 @@ func (s *RingpopTestSuite) TestUptime() {
 // TestChecksum tests that Checksum only operates when the Ringpop instance is in
 // a ready state.
 func (s *RingpopTestSuite) TestChecksum() {
-
 	s.NotEqual(ready, s.ringpop.state)
 	checksum, err := s.ringpop.Checksum()
 	s.Zero(checksum)

--- a/stats_handler.go
+++ b/stats_handler.go
@@ -37,6 +37,8 @@ func handleStats(rp *Ringpop) map[string]interface{} {
 
 	type stats map[string]interface{}
 
+	uptime, _ := rp.Uptime()
+
 	return stats{
 		"hooks":      nil,
 		"membership": rp.node.MemberStats(),
@@ -55,7 +57,7 @@ func handleStats(rp *Ringpop) map[string]interface{} {
 		},
 		"version":         "???", // TODO: version!
 		"timestamp":       time.Now().Unix(),
-		"uptime":          rp.Uptime(),
+		"uptime":          uptime,
 		"tchannelVersion": strconv.Itoa(tchannel.CurrentProtocolVersion), // get proper version
 	}
 }


### PR DESCRIPTION
This change delays initialization of swim node set up, stats set up and
default handler registration until bootstrapping.

Crucially, this also delays resolution of the listen address until
bootstrap is called. This means a TChannel object that is not yet
listening can be passed to the ringpop constructor.

See PR #34 for history.

@uber/ringpop 