### PR TITLE
Automatically add self to bootstrap list

### DIFF
--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -40,17 +40,9 @@ type RingpopTestSuite struct {
 // createSingleNodeCluster is a helper function to create a single-node cluster
 // during the tests
 func createSingleNodeCluster(rp *Ringpop) error {
-	// We must resolve the identity in order to be able to Bootstrap with the
-	// correct options.
-	identity, err := rp.identity()
-	if err != nil {
-		return err
-	}
-
-	// Bootstrapping with a single host that matches the Ringpop instance's
-	// identity will created a single-node cluster.
-	_, err = rp.Bootstrap(&swim.BootstrapOptions{
-		Hosts: []string{identity},
+	// Bootstrapping with an empty list will created a single-node cluster.
+	_, err := rp.Bootstrap(&swim.BootstrapOptions{
+		Hosts: []string{},
 	})
 
 	return err
@@ -340,6 +332,13 @@ func (s *RingpopTestSuite) TestGetReachableMembersNotReady() {
 	result, err := s.ringpop.GetReachableMembers()
 	s.Error(err)
 	s.Nil(result)
+}
+
+// TestEmptyJoinListCreatesSingleNodeCluster tests that when you call Bootstrap
+// with no hosts or bootstrap file, a single-node cluster is created.
+func (s *RingpopTestSuite) TestEmptyJoinListCreatesSingleNodeCluster() {
+	createSingleNodeCluster(s.ringpop)
+	s.Equal(ready, s.ringpop.state)
 }
 
 func TestRingpopTestSuite(t *testing.T) {

--- a/util.go
+++ b/util.go
@@ -36,3 +36,12 @@ func (noopStatsReporter) RecordTimer(name string, tags bark.Tags, d time.Duratio
 func genStatsHostport(hostport string) string {
 	return strings.Replace(strings.Replace(hostport, ".", "_", -1), ":", "_", -1)
 }
+
+func stringInSlice(s []string, a string) bool {
+	for _, b := range s {
+		if a == b {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
When bootstrapping, the swim node expects to see the local (current)
host identity in the bootstrap list. It prints a warning if not.

This change makes ringpop automatically add the current host identity to
the bootstrap list if it is missing.

More importantly, if ringpop.Bootstrap is called with no hosts (i.e. no
bootstrap file and no hosts in the bootstrap list) this will
automatically create a single-node cluster.

@uber/ringpop 