### PR TITLE
Fix bug preventing bootstrapping from file

### DIFF
--- a/ringpop.go
+++ b/ringpop.go
@@ -87,7 +87,7 @@ type Ringpop struct {
 
 	channel    shared.TChannel
 	subChannel shared.SubChannel
-	node       *swim.Node
+	node       swim.NodeInterface
 	ring       HashRing
 	forwarder  *forward.Forwarder
 
@@ -293,11 +293,12 @@ func (rp *Ringpop) Bootstrap(userBootstrapOpts *swim.BootstrapOptions) ([]string
 		return nil, err
 	}
 
-	// Check we're in the bootstrap host list and add ourselves if we're not
+	// If the user has provided a list of hosts (and not a bootstrap file),
+	// check we're in the bootstrap host list and add ourselves if we're not
 	// there. If the host list is empty, this will create a single-node
 	// cluster.
 	bootstrapOpts := *userBootstrapOpts
-	if !stringInSlice(bootstrapOpts.Hosts, identity) {
+	if len(bootstrapOpts.File) == 0 && !stringInSlice(bootstrapOpts.Hosts, identity) {
 		bootstrapOpts.Hosts = append(bootstrapOpts.Hosts, identity)
 	}
 

--- a/swim/node.go
+++ b/swim/node.go
@@ -108,6 +108,17 @@ func mergeDefaultOptions(opts *Options) *Options {
 	return opts
 }
 
+type NodeInterface interface {
+	Bootstrap(opts *BootstrapOptions) ([]string, error)
+	CountReachableMembers() int
+	Destroy()
+	GetReachableMembers() []string
+	MemberStats() MemberStats
+	ProtocolStats() ProtocolStats
+	Ready() bool
+	RegisterListener(l EventListener)
+}
+
 // A Node is a SWIM member
 type Node struct {
 	app     string

--- a/test/gen-mocks
+++ b/test/gen-mocks
@@ -18,4 +18,11 @@ mockery -name Interface -print \
     |sed 's/type Interface/type Ringpop/g' \
     > "$mock_directory"/ringpop.go
 
+echo
+
+mockery -name NodeInterface -recursive -print \
+    |sed 's/_m \*NodeInterface/_m \*SwimNode/g' \
+    |sed 's/type NodeInterface/type SwimNode/g' \
+    > "$mock_directory"/swim_node.go
+
 mockery -case=underscore -dir router -recursive -output "$mock_directory" -name ClientFactory

--- a/test/mocks/swim_node.go
+++ b/test/mocks/swim_node.go
@@ -1,0 +1,98 @@
+package mocks
+
+import "github.com/uber/ringpop-go/swim"
+import "github.com/stretchr/testify/mock"
+
+type SwimNode struct {
+	mock.Mock
+}
+
+func (_m *SwimNode) Bootstrap(opts *swim.BootstrapOptions) ([]string, error) {
+	ret := _m.Called(opts)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(*swim.BootstrapOptions) []string); ok {
+		r0 = rf(opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*swim.BootstrapOptions) error); ok {
+		r1 = rf(opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+func (_m *SwimNode) CountReachableMembers() int {
+	ret := _m.Called()
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+func (_m *SwimNode) Destroy() {
+	_m.Called()
+}
+func (_m *SwimNode) GetReachableMembers() []string {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	return r0
+}
+func (_m *SwimNode) MemberStats() swim.MemberStats {
+	ret := _m.Called()
+
+	var r0 swim.MemberStats
+	if rf, ok := ret.Get(0).(func() swim.MemberStats); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(swim.MemberStats)
+	}
+
+	return r0
+}
+func (_m *SwimNode) ProtocolStats() swim.ProtocolStats {
+	ret := _m.Called()
+
+	var r0 swim.ProtocolStats
+	if rf, ok := ret.Get(0).(func() swim.ProtocolStats); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(swim.ProtocolStats)
+	}
+
+	return r0
+}
+func (_m *SwimNode) Ready() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+func (_m *SwimNode) RegisterListener(l swim.EventListener) {
+	_m.Called(l)
+}


### PR DESCRIPTION
PR #41 introduced an enhancement where Ringpop will automatically add
the current/local node's identity to the Host list of
swim.BootstrapOptions.

This broke file-based bootstrapping, as the host identity was always
added to the Hosts field, even when file-based bootstrapping was used.

swim.Node reads the Host list as priority over reading a file, so this
caused file-based bootstrapping to always create a single-node cluster.

This fix checks that a File has not been specified before first adding
the node's identity to the Host list.