### PR TITLE
Fix swim tests

### DIFF
--- a/swim/bootstrap_test.go
+++ b/swim/bootstrap_test.go
@@ -37,7 +37,7 @@ type BootstrapTestSuite struct {
 }
 
 func (s *BootstrapTestSuite) SetupTest() {
-	s.tnode = newChannelNode(s.T(), "127.0.0.1:3001")
+	s.tnode = newChannelNode(s.T())
 	s.node = s.tnode.node
 }
 
@@ -46,14 +46,14 @@ func (s *BootstrapTestSuite) TearDownTest() {
 }
 
 func (s *BootstrapTestSuite) TestBootstrapOk() {
-	s.peers = genChannelNodes(s.T(), genAddresses(1, 2, 6))
+	s.peers = genChannelNodes(s.T(), 5)
 
 	bootstrapNodes(s.T(), append(s.peers, s.tnode)...)
 }
 
 func (s *BootstrapTestSuite) TestBootstrapTimesOut() {
 	_, err := s.node.Bootstrap(&BootstrapOptions{
-		Hosts:           genAddresses(1, 1, 10),
+		Hosts:           fakeHostPorts(1, 1, 1, 0),
 		MaxJoinDuration: time.Millisecond,
 	})
 
@@ -62,7 +62,7 @@ func (s *BootstrapTestSuite) TestBootstrapTimesOut() {
 
 func (s *BootstrapTestSuite) TestBootstrapJoinsTimeOut() {
 	_, err := s.node.Bootstrap(&BootstrapOptions{
-		Hosts:           append(genAddresses(2, 1, 5), s.node.Address()),
+		Hosts:           append(fakeHostPorts(2, 2, 1, 5), s.node.Address()),
 		MaxJoinDuration: time.Millisecond,
 		JoinTimeout:     time.Millisecond / 2,
 	})
@@ -75,7 +75,7 @@ func (s *BootstrapTestSuite) TestBootstrapDestroy() {
 
 	go func() {
 		_, err := s.node.Bootstrap(&BootstrapOptions{
-			Hosts:       genAddresses(1, 1, 10),
+			Hosts:       fakeHostPorts(1, 1, 1, 0),
 			JoinTimeout: time.Millisecond,
 		})
 		lerr.Set(err)

--- a/swim/disseminator_test.go
+++ b/swim/disseminator_test.go
@@ -37,7 +37,10 @@ type DisseminatorTestSuite struct {
 
 func (s *DisseminatorTestSuite) SetupTest() {
 	s.incarnation = util.TimeNowMS()
-	s.node = NewNode("test", "127.0.0.1:3001", nil, nil)
+
+	fakeAddress := fakeHostPorts(1, 1, 1, 1)[0]
+	s.node = NewNode("test", fakeAddress, nil, nil)
+
 	s.node.memberlist.MakeAlive(s.node.Address(), s.incarnation)
 	s.d = s.node.disseminator
 	s.m = s.node.memberlist
@@ -48,7 +51,7 @@ func (s *DisseminatorTestSuite) TearDownTest() {
 }
 
 func (s *DisseminatorTestSuite) TestChangesAreRecorded() {
-	addresses := genAddresses(1, 2, 4)
+	addresses := fakeHostPorts(1, 1, 2, 4)
 
 	for _, address := range addresses {
 		s.m.MakeAlive(address, s.incarnation)
@@ -58,7 +61,7 @@ func (s *DisseminatorTestSuite) TestChangesAreRecorded() {
 }
 
 func (s *DisseminatorTestSuite) TestFullSync() {
-	addresses := genAddresses(1, 2, 4)
+	addresses := fakeHostPorts(1, 1, 2, 4)
 
 	for _, address := range addresses {
 		s.m.MakeAlive(address, s.incarnation)

--- a/swim/gossip_test.go
+++ b/swim/gossip_test.go
@@ -36,7 +36,7 @@ type GossipTestSuite struct {
 }
 
 func (s *GossipTestSuite) SetupTest() {
-	s.tnode = newChannelNode(s.T(), "127.0.0.1:3001")
+	s.tnode = newChannelNode(s.T())
 	s.node = s.tnode.node
 
 	s.g = s.node.gossip
@@ -75,7 +75,7 @@ func (s *GossipTestSuite) StopWhileStopped() {
 }
 
 func (s *GossipTestSuite) TestUpdatesArePropogated() {
-	peer := newChannelNode(s.T(), "127.0.0.1:3002")
+	peer := newChannelNode(s.T())
 	defer peer.Destroy()
 	defer peer.channel.Close()
 
@@ -107,7 +107,7 @@ func (s *GossipTestSuite) TestUpdatesArePropogated() {
 
 // TODO: move this test to node_test?
 func (s *GossipTestSuite) TestSuspicionStarted() {
-	peers := genChannelNodes(s.T(), genAddresses(1, 2, 4))
+	peers := genChannelNodes(s.T(), 3)
 	defer destroyNodes(peers...)
 
 	bootstrapNodes(s.T(), append(peers, s.tnode)...)

--- a/swim/memberlist_iter_test.go
+++ b/swim/memberlist_iter_test.go
@@ -58,7 +58,7 @@ func (s *MemberlistIterTestSuite) TestNoneUseable() {
 }
 
 func (s *MemberlistIterTestSuite) TestIterOverFive() {
-	addresses := genAddresses(1, 2, 6)
+	addresses := fakeHostPorts(1, 1, 2, 6)
 
 	for _, address := range addresses {
 		s.m.MakeAlive(address, s.incarnation)

--- a/swim/ping_request_test.go
+++ b/swim/ping_request_test.go
@@ -38,9 +38,9 @@ type PingRequestTestSuite struct {
 
 func (s *PingRequestTestSuite) SetupTest() {
 	s.incarnation = util.TimeNowMS()
-	s.tnode = newChannelNode(s.T(), "127.0.0.1:3001")
+	s.tnode = newChannelNode(s.T())
 	s.node = s.tnode.node
-	s.peers = genChannelNodes(s.T(), genAddresses(1, 2, 3))
+	s.peers = genChannelNodes(s.T(), 2)
 }
 
 func (s *PingRequestTestSuite) TearDownTest() {

--- a/swim/ping_sender.go
+++ b/swim/ping_sender.go
@@ -64,7 +64,10 @@ func (p *pingSender) SendPing() (*ping, error) {
 	var res ping
 	select {
 	case err := <-p.MakeCall(ctx, &res):
-		return &res, err
+		if err != nil {
+			return nil, err
+		}
+		return &res, nil
 
 	case <-ctx.Done(): // ping timed out
 		return nil, errors.New("ping timed out")

--- a/swim/suspicion_test.go
+++ b/swim/suspicion_test.go
@@ -103,17 +103,21 @@ func (s *SuspicionTestSuite) TestSuspectBecomesFaulty() {
 	s.Equal(Faulty, member.Status, "expected member to be faulty")
 }
 
-func (s *SuspicionTestSuite) TestTimerChanges() {
+// TestTimerCreated tests that starting suspicion for a node creates a
+// countdown timer that is responsible for marking a node as faulty at the end
+// of the timeout.
+func (s *SuspicionTestSuite) TestTimerCreated() {
 	s.m.MakeAlive(s.suspect.Address, s.suspect.Incarnation)
 	member, _ := s.m.Member(s.suspect.Address)
 	s.Require().NotNil(member, "expected cannot be nil")
 
-	s.s.Start(*member)
 	old := s.s.Timer(member.Address)
+	s.Require().Nil(old, "expected timer to be nil")
 
+	// Start suspcision, which should create a timer
 	s.s.Start(*member)
 
-	s.NotEqual(old, s.s.Timer(member.Address), "expected timer to changed")
+	s.NotEqual(old, s.s.Timer(member.Address), "expected timer to change")
 }
 
 func (s *SuspicionTestSuite) TestSuspicionDisableStopsTimers() {


### PR DESCRIPTION
This PR fixes a couple of out-of-date tests. However, the most significant change is a fix to flappy tests.

Previously, tests were binding to static ports ("127.0.0.1:3001", etc). Some tests were flapping due to previous tests already listening on these ports. Tests that require actual listening channels now listen on port 0.

Tests that don't actually require anything to be listening are now using the 192.0.2.0 network, which is defined by RFC 5737 as TEST-NET-1 and should be non-routable or at least non-existent on the internet.