### PR TITLE
Rework hashring locks plus 100% test coverage

### DIFF
--- a/options.go
+++ b/options.go
@@ -108,7 +108,7 @@ func Channel(ch shared.TChannel) Option {
 //
 // See documentation on the `HashRingConfiguration` struct for more information
 // about what options are available.
-func HashRingConfig(c *hashring.HashRingConfiguration) Option {
+func HashRingConfig(c *hashring.Configuration) Option {
 	return func(r *Ringpop) error {
 		r.configHashRing = c
 		return nil
@@ -204,6 +204,6 @@ var defaultOptions = []Option{
 	defaultHashRingOptions,
 }
 
-var defaultHashRingConfiguration = &hashring.HashRingConfiguration{
+var defaultHashRingConfiguration = &hashring.Configuration{
 	ReplicaPoints: 100,
 }

--- a/options_test.go
+++ b/options_test.go
@@ -124,7 +124,7 @@ func (s *RingpopOptionsTestSuite) TestStatter() {
 // applied and used correctly.
 func (s *RingpopOptionsTestSuite) TestHashRingConfig() {
 	rp, err := New("test", Channel(s.channel), HashRingConfig(
-		&hashring.HashRingConfiguration{
+		&hashring.Configuration{
 			ReplicaPoints: 42,
 		}),
 	)

--- a/ringpop.go
+++ b/ringpop.go
@@ -35,11 +35,10 @@ import (
 	log "github.com/uber-common/bark"
 	"github.com/uber/ringpop-go/events"
 	"github.com/uber/ringpop-go/forward"
+	"github.com/uber/ringpop-go/hashring"
 	"github.com/uber/ringpop-go/shared"
 	"github.com/uber/ringpop-go/swim"
 	"github.com/uber/tchannel-go"
-
-	"github.com/uber/ringpop-go/hashring"
 )
 
 // Interface specifies the public facing methods a user of ringpop is able to
@@ -65,7 +64,7 @@ type Interface interface {
 // changes around the ring.
 type Ringpop struct {
 	config         *configuration
-	configHashRing *hashring.HashRingConfiguration
+	configHashRing *hashring.Configuration
 
 	identityResolver IdentityResolver
 
@@ -164,7 +163,7 @@ func (rp *Ringpop) init() error {
 	})
 	rp.node.RegisterListener(rp)
 
-	rp.ring = hashring.NewHashRing(farm.Fingerprint32, rp.configHashRing.ReplicaPoints)
+	rp.ring = hashring.New(farm.Fingerprint32, rp.configHashRing.ReplicaPoints)
 	rp.ring.RegisterListener(rp)
 
 	rp.stats.hostport = genStatsHostport(address)

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -87,14 +87,14 @@ func (s *RingpopTestSuite) TestHandlesMemberlistChangeEvent() {
 		Changes: genChanges(genAddresses(1, 1, 10), swim.Alive),
 	})
 
-	s.Len(s.ringpop.ring.GetServers(), 10)
+	s.Equal(s.ringpop.ring.ServerCount(), 10)
 
 	alive, faulty := genAddresses(1, 11, 15), genAddresses(1, 1, 5)
 	s.ringpop.HandleEvent(swim.MemberlistChangesAppliedEvent{
 		Changes: append(genChanges(alive, swim.Alive), genChanges(faulty, swim.Faulty)...),
 	})
 
-	s.Len(s.ringpop.ring.GetServers(), 10)
+	s.Equal(s.ringpop.ring.ServerCount(), 10)
 	for _, address := range alive {
 		s.True(s.ringpop.ring.HasServer(address))
 	}

--- a/stats_handler.go
+++ b/stats_handler.go
@@ -33,7 +33,7 @@ func handleStats(rp *Ringpop) map[string]interface{} {
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 
-	servers := rp.ring.GetServers()
+	servers := rp.ring.Servers()
 
 	type stats map[string]interface{}
 


### PR DESCRIPTION
Some refactoring due to locks. Now only locking exported functions and make a very clear distinction in comments and function names on which functions close the lock.

Flattened out the servers struct in the HashRing which provided no clear benefit.

More idiomatic go naming: e.g. NewHashRing -> New

Use strings.Join in computeChecksum instead of a manual approach.