### PR TITLE
Improve test that verifies correct behavior of a destroyed node durin…

### DIFF
--- a/swim/test_utils.go
+++ b/swim/test_utils.go
@@ -22,7 +22,6 @@ package swim
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -52,24 +51,6 @@ func (dummyIter) Next() (*Member, bool) {
 		Status:      Alive,
 		Incarnation: testInc,
 	}, true
-}
-
-type lError struct {
-	err error
-	sync.Mutex
-}
-
-func (e *lError) Set(err error) {
-	e.Lock()
-	e.err = err
-	e.Unlock()
-}
-
-func (e *lError) Err() error {
-	e.Lock()
-	err := e.err
-	e.Unlock()
-	return err
 }
 
 type testNode struct {


### PR DESCRIPTION
…g bootstrap by making using of channels not sleeps

This test depended upon appropriately timed sleep statements for correct behavior. I've taken out the sleeps and replaced with a error sharing over a channel.

Regarding why this is being done (other than to take variability out), it seems as though that by changing the timing of tests and join sender, the test will fail.

@uber/ringpop 