### PR TITLE
Introduce exponentially increasing delay after each join attempt

### DIFF
--- a/swim/join_delayer.go
+++ b/swim/join_delayer.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package swim
+
+import (
+	"errors"
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/uber-common/bark"
+	"github.com/uber/ringpop-go/util"
+)
+
+var errLoggerRequired = errors.New("joinDelayer requires a logger")
+
+const (
+	defaultInitial = 100 * time.Millisecond
+	defaultMax     = 60 * time.Second
+)
+
+var delayerRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+var defaultRandomizer = delayerRand.Intn
+var defaultSleeper = time.Sleep
+var noDelay = time.Duration(0)
+
+// joinDelayer defines the API of a delayer implementation that
+// applies a delay in between repeated join attempts.
+type joinDelayer interface {
+	delay() time.Duration
+}
+
+// delayRandomizer is a function that returns a random number between
+// 0 and an upper-bound, provided in its first argument.
+type delayRandomizer func(int) int
+
+// delaySleeper is a function that pauses execution for time.Duration.
+type delaySleeper func(time.Duration)
+
+// delayOpts is a struct that houses substitutable parameters of a joinDelayer
+// in order to alter its behavior.
+type delayOpts struct {
+	initial    time.Duration
+	max        time.Duration
+	randomizer delayRandomizer
+	sleeper    delaySleeper
+}
+
+// newDelayOpts creates a delayOpts struct with default values.
+func newDelayOpts() *delayOpts {
+	return &delayOpts{
+		initial:    defaultInitial,
+		max:        defaultMax,
+		randomizer: defaultRandomizer,
+		sleeper:    defaultSleeper,
+	}
+}
+
+// exponentialDelayer applies a delay in between repeated join attempts.
+// The delay increases exponentially and is capped at maxDelay.
+type exponentialDelayer struct {
+	// joiner is the address of the node sending join requests.
+	joiner string
+
+	// logger logs when a maximum delay is reached.
+	logger bark.Logger
+
+	// initialDelay is the fixed portion of the delay by which
+	// the exponential backoff is multiplied.
+	initialDelay time.Duration
+
+	// maxDelay is the maximum delay applied to a join attempt.
+	maxDelay time.Duration
+
+	// maxDelayReached is a flag that is toggled once the delay
+	// applied to a join attempt reaches or exceeds the max delay.
+	maxDelayReached bool
+
+	// nextDelayMin tracks the last used upper-bound for a join attempt delay.
+	// Upon the next join attempt, nextDelayMin will be used as the lower-bound
+	// for that delay. This acts as a shifting window for the bounds of the
+	// exponential backoff.
+	nextDelayMin float64
+
+	// randomizer generates a random delay in between a nextDelayMin
+	// and maxDelay.
+	randomizer delayRandomizer
+
+	// sleeper pauses execution of a join attempt.
+	sleeper delaySleeper
+
+	// numDelays tracks the number of times delay has been called on the
+	// delayer. It's also used as the backoff exponent.
+	numDelays uint
+}
+
+// newExponentialDelayer creates a new exponential delayer. joiner and logger
+// are required. opts is optional.
+func newExponentialDelayer(joiner string, logger bark.Logger,
+	opts *delayOpts) (*exponentialDelayer, error) {
+	if logger == nil {
+		return nil, errLoggerRequired
+	}
+
+	if opts == nil {
+		opts = newDelayOpts()
+	}
+
+	randomizer := opts.randomizer
+	if randomizer == nil {
+		randomizer = defaultRandomizer
+	}
+
+	sleeper := opts.sleeper
+	if sleeper == nil {
+		sleeper = defaultSleeper
+	}
+
+	return &exponentialDelayer{
+		joiner:          joiner,
+		logger:          logger,
+		initialDelay:    opts.initial,
+		nextDelayMin:    0,
+		maxDelayReached: false,
+		maxDelay:        opts.max,
+		randomizer:      randomizer,
+		sleeper:         sleeper,
+		numDelays:       0,
+	}, nil
+}
+
+// delay delays a join attempt by sleeping for an amount of time. The
+// amount of time is computed as an exponential backoff based on the number
+// of join attempts that have been made at the time of the function call;
+// the number of attempts is 0-based. It returns a time.Duration equal to the
+// amount of delay applied.
+func (d *exponentialDelayer) delay() time.Duration {
+	// Convert durations to time in millis
+	initialDelayMs := float64(util.MS(d.initialDelay))
+	maxDelayMs := float64(util.MS(d.maxDelay))
+
+	// Compute uncapped exponential delay (exponent is the number of join
+	// attempts so far). Then, make sure the computed delay is capped at its
+	// max. Apply a random jitter to the actual sleep duration and finally,
+	// sleep.
+	uncappedDelay := initialDelayMs * math.Pow(2, float64(d.numDelays))
+	cappedDelay := math.Min(maxDelayMs, uncappedDelay)
+
+	// If cappedDelay and nextDelayMin are equal, we have reached the point
+	// at which the exponential backoff has reached its max; apply no more
+	// jitter.
+	var jitteredDelay int
+	if cappedDelay == d.nextDelayMin {
+		jitteredDelay = int(cappedDelay)
+	} else {
+		jitteredDelay = d.randomizer(int(cappedDelay-d.nextDelayMin)) + int(d.nextDelayMin)
+	}
+
+	// If this is the first time an uncapped delay reached or exceeded the
+	// maximum allowable delay, log a message.
+	if uncappedDelay >= maxDelayMs && d.maxDelayReached == false {
+		d.logger.WithFields(bark.Fields{
+			"local":         d.joiner,
+			"numDelays":     d.numDelays,
+			"initialDelay":  d.initialDelay,
+			"minDelay":      d.nextDelayMin,
+			"maxDelay":      d.maxDelay,
+			"uncappedDelay": uncappedDelay,
+			"cappedDelay":   cappedDelay,
+			"jitteredDelay": jitteredDelay,
+		}).Warn("ringpop join attempt delay reached max")
+		d.maxDelayReached = true
+	}
+
+	// Set lower-bound for next attempt to maximum of current attempt.
+	d.nextDelayMin = cappedDelay
+
+	sleepDuration := time.Duration(jitteredDelay) * time.Millisecond
+	d.sleeper(sleepDuration)
+
+	// Increment the exponent used for backoff calculation.
+	d.numDelays++
+
+	return sleepDuration
+}
+
+// nullDelayer is an empty implementation of joinDelayer.
+type nullDelayer struct{}
+
+// delay applies no delay.
+func (d *nullDelayer) delay() time.Duration {
+	return time.Duration(0)
+}

--- a/swim/join_delayer_test.go
+++ b/swim/join_delayer_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package swim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber/ringpop-go/swim/test/mocks"
+)
+
+// Null randomizer and sleeper used for join delay tests.
+var noRandom = func(n int) int { return n }
+var noSleep = func(d time.Duration) {}
+
+type joinDelayerTestSuite struct {
+	suite.Suite
+	delayer        *exponentialDelayer
+	expectedDelays [6]time.Duration
+}
+
+func (s *joinDelayerTestSuite) SetupTest() {
+	opts := &delayOpts{
+		initial: 100 * time.Millisecond,
+		max:     1 * time.Second,
+		sleeper: noSleep, // Sleeper used for tests applies no actual delay
+	}
+
+	// Represents the steps of a complete exponential backoff
+	// as implemented by the exponentialDelayer.
+	s.expectedDelays = [...]time.Duration{
+		opts.initial,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+		opts.max, // Backoff delay is capped at this point.
+		opts.max,
+	}
+
+	var logger *mocks.Logger
+	logger = &mocks.Logger{}
+	logger.On("WithFields", mock.Anything).Return(logger)
+	logger.On("Warn", mock.Anything).Return(nil)
+
+	delayer, err := newExponentialDelayer("dummyjoiner", logger, opts)
+	s.NoError(err, "expected valid exponential delayer")
+	s.delayer = delayer
+}
+
+func (s *joinDelayerTestSuite) TestDelayWithRandomness() {
+	for i, expectedDelay := range s.expectedDelays {
+		delay := s.delayer.delay()
+		if i == 0 {
+			s.True(delay >= 0 && delay < expectedDelay,
+				"first delay should be between 0 and min")
+		} else {
+			s.True(delay >= s.expectedDelays[i-1] && delay <= expectedDelay,
+				"next delays should be within bounds")
+		}
+	}
+}
+
+func (s *joinDelayerTestSuite) TestDelayWithoutRandomness() {
+	// Substitute delayer's randomizer with one that produces
+	// no randomness whatsoever.
+	s.delayer.randomizer = noRandom
+
+	for _, expectedDelay := range s.expectedDelays {
+		delay := s.delayer.delay()
+		s.EqualValues(expectedDelay, delay, "join attempt delay is correct")
+	}
+}
+
+func (s *joinDelayerTestSuite) TestDelayerPreconditions() {
+	_, err := newExponentialDelayer("dummyjoiner", nil, nil)
+	s.Equal(err, errLoggerRequired, "logger required error")
+}
+
+func (s *joinDelayerTestSuite) TestMaxDelayReached() {
+	for i := range s.expectedDelays {
+		s.delayer.delay()
+		// This condition assumes that the last two elements
+		// of expectedDelay is equal to the max delay.
+		if i < len(s.expectedDelays)-2 {
+			s.False(s.delayer.maxDelayReached, "max delay not reached")
+		} else {
+			s.True(s.delayer.maxDelayReached, "max delay not reached")
+		}
+	}
+}
+
+func TestJoinDelayerTestSuite(t *testing.T) {
+	suite.Run(t, new(joinDelayerTestSuite))
+}

--- a/swim/join_test.go
+++ b/swim/join_test.go
@@ -199,6 +199,16 @@ func (s *JoinSenderTestSuite) TestJoinSelf() {
 	}
 }
 
+func (s *JoinSenderTestSuite) TestCustomDelayer() {
+	delayer := &nullDelayer{}
+	joiner, err := newJoinSender(s.node, &joinOpts{
+		delayer:          delayer,
+		discoverProvider: &StaticHostList{fakeHostPorts(1, 1, 1, 1)},
+	})
+	s.NoError(err, "expected valid joiner")
+	s.Equal(delayer, joiner.delayer, "custom delayer was set")
+}
+
 func TestJoinSenderTestSuite(t *testing.T) {
 	suite.Run(t, new(JoinSenderTestSuite))
 }


### PR DESCRIPTION
This PR adds a delay in between each join attempt. The delay is a calculation of an exponential backoff with added jitter/fuzz. The maximum potential delay will increase until it is capped at its max. The actual delay will be a random number between the last used max and the new max. Therefore, after the first join attempt, the delay will be between 0 and 100. On the second attempt, 100 and 200. On the third attempt, between 200 and 400 and so on.

cc @uber/ringpop 