### PR TITLE
Dedupe destinations before forwarded request is retried

### DIFF
--- a/forward/mock_logger.go
+++ b/forward/mock_logger.go
@@ -1,0 +1,81 @@
+package forward
+
+import "github.com/uber-common/bark"
+import "github.com/stretchr/testify/mock"
+
+type Logger struct {
+	mock.Mock
+}
+
+func (_m *Logger) Debug(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Debugf(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) Info(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Infof(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) Warn(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Warnf(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) Error(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Errorf(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) Fatal(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Fatalf(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) Panic(args ...interface{}) {
+	_m.Called(args)
+}
+func (_m *Logger) Panicf(format string, args ...interface{}) {
+	_m.Called(format, args)
+}
+func (_m *Logger) WithField(key string, value interface{}) bark.Logger {
+	ret := _m.Called(key, value)
+
+	var r0 bark.Logger
+	if rf, ok := ret.Get(0).(func(string, interface{}) bark.Logger); ok {
+		r0 = rf(key, value)
+	} else {
+		r0 = ret.Get(0).(bark.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) WithFields(keyValues bark.LogFields) bark.Logger {
+	ret := _m.Called(keyValues)
+
+	var r0 bark.Logger
+	if rf, ok := ret.Get(0).(func(bark.LogFields) bark.Logger); ok {
+		r0 = rf(keyValues)
+	} else {
+		r0 = ret.Get(0).(bark.Logger)
+	}
+
+	return r0
+}
+func (_m *Logger) Fields() bark.Fields {
+	ret := _m.Called()
+
+	var r0 bark.Fields
+	if rf, ok := ret.Get(0).(func() bark.Fields); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bark.Fields)
+	}
+
+	return r0
+}

--- a/forward/request_sender_test.go
+++ b/forward/request_sender_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package forward
+
+import (
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber/ringpop-go/shared"
+	"github.com/uber/tchannel-go"
+	"testing"
+)
+
+type requestSenderTestSuite struct {
+	suite.Suite
+	requestSender *requestSender
+	mockSender    *MockSender
+}
+
+type dummies struct {
+	channel  shared.SubChannel
+	dest     string
+	emitter  eventEmitter
+	endpoint string
+	format   tchannel.Format
+	keys     []string
+	options  *Options
+	request  []byte
+	service  string
+}
+
+func (s *requestSenderTestSuite) SetupTest() {
+	mockSender := &MockSender{}
+	dummies := s.newDummies(mockSender)
+	s.requestSender = newRequestSender(mockSender, dummies.emitter,
+		dummies.channel, dummies.request, dummies.keys, dummies.dest,
+		dummies.service, dummies.endpoint, dummies.format, dummies.options)
+	s.mockSender = mockSender
+}
+
+func (s *requestSenderTestSuite) newDummies(mockSender *MockSender) *dummies {
+	channel, err := tchannel.NewChannel("dummychannel", nil)
+	s.NoError(err, "no error creating TChannel")
+
+	return &dummies{
+		channel:  channel,
+		dest:     "dummydest",
+		endpoint: "/dummyendpoint",
+		emitter:  NewForwarder(mockSender, channel, newDummyLogger()),
+		format:   tchannel.Thrift,
+		keys:     []string{},
+		options: &Options{
+			Logger: newDummyLogger(),
+		},
+		request: []byte{},
+		service: "dummyservice",
+	}
+}
+
+func newDummyLogger() *Logger {
+	logger := &Logger{}
+	logger.On("WithFields", mock.Anything).Return(logger)
+	logger.On("Warn", mock.Anything).Return(nil)
+	return logger
+}
+
+func stubLookupWithKeys(mockSender *MockSender, dest string, keys ...string) {
+	for _, key := range keys {
+		mockSender.On("Lookup", key).Return(dest, nil)
+	}
+}
+
+func (s *requestSenderTestSuite) TestAttemptRetrySendsMultipleKeys() {
+	s.mockSender.On("WhoAmI").Return("192.0.2.1:0", nil)
+	stubLookupWithKeys(s.mockSender, "192.0.2.1:1", "key1", "key2")
+
+	// Mutate keys that are looked up prior to attempted retry.
+	s.requestSender.keys = []string{"key1", "key2"}
+
+	_, err := s.requestSender.AttemptRetry()
+	s.NotEqual(errDestinationsDiverged, err, "not a diverged error")
+}
+
+func (s *requestSenderTestSuite) TestLookupKeysDedupes() {
+	// 2 groups of 2 keys. Each group hashes to a different destination.
+	stubLookupWithKeys(s.mockSender, "192.0.2.1:1", "key1", "key2")
+	stubLookupWithKeys(s.mockSender, "192.0.2.1:2", "key3", "key4")
+
+	dests := s.requestSender.LookupKeys([]string{"key1", "key2"})
+	s.Len(dests, 1, "dedupes single destination for multiple keys")
+
+	dests = s.requestSender.LookupKeys([]string{"key1", "key2", "key3", "key4"})
+	s.Len(dests, 2, "dedupes multiple destinations for multiple keys")
+}
+
+func TestRequestSenderTestSuite(t *testing.T) {
+	suite.Run(t, new(requestSenderTestSuite))
+}

--- a/test/gen-testfiles
+++ b/test/gen-testfiles
@@ -34,6 +34,9 @@ mockery -case=underscore -dir router -recursive -output "$mock_directory" -name 
 mockery -name EventListener -dir events -recursive -print \
     |sed 's/package mocks/package forward/g' \
     > "${0%/*}/../forward/mock_event_listener_test.go"
+mockery -name Logger -dir "$GOPATH"/src/github.com/uber-common/bark -recursive -print \
+    | sed 's/package mocks/package forward/g' \
+    > "${0%/*}/../forward/mock_logger.go"
 
 # mocks used in forward cannot go into test/mocks because circular dependency
 mockery -name Sender -dir forward -recursive -testonly -case=underscore -inpkg

--- a/test/mocks/ringpop.go
+++ b/test/mocks/ringpop.go
@@ -8,6 +8,7 @@ import "github.com/uber/ringpop-go/events"
 import "github.com/uber/ringpop-go/forward"
 
 import "github.com/uber/ringpop-go/swim"
+
 import "github.com/uber/tchannel-go"
 
 type Ringpop struct {


### PR DESCRIPTION
There exists a bug in Ringpop's forwarding mechanism that will return a "divergence error" if any request containing multiple keys is ever retried. This happens to be the case because LookupKeys does not dedupe destinations when a lookup is attempted just prior to the retry.

@uber/ringpop 