### PR TITLE
Ws ping reqs bug fix

### DIFF
--- a/swim/events.go
+++ b/swim/events.go
@@ -31,6 +31,15 @@ type EventListener interface {
 	HandleEvent(events.Event)
 }
 
+// The ListenerFunc type is an adapter to allow the use of ordinary functions
+// as EventListeners.
+type ListenerFunc func(events.Event)
+
+// HandleEvent calls f(e).
+func (f ListenerFunc) HandleEvent(e events.Event) {
+	f(e)
+}
+
 // A MaxPAdjustedEvent occurs when the disseminator adjusts the max propagation
 // count for changes
 type MaxPAdjustedEvent struct {
@@ -121,11 +130,20 @@ type PingRequestsSendEvent struct {
 	Peers  []string `json:"peers"`
 }
 
+// A PingRequestSendError is sent when the node can't get a response sending ping requests to remote nodes
+type PingRequestSendErrorEvent struct {
+	Local  string   `json:"local"`
+	Target string   `json:"target"`
+	Peers  []string `json:"peers"`
+	Peer   string   `json:"peer"`
+}
+
 // A PingRequestsSendCompleteEvent is sent when the node finished sending ping requests to remote nodes
 type PingRequestsSendCompleteEvent struct {
 	Local    string        `json:"local"`
 	Target   string        `json:"target"`
 	Peers    []string      `json:"peers"`
+	Peer     string        `json:"peer"`
 	Duration time.Duration `json:"duration"`
 }
 

--- a/swim/join_test.go
+++ b/swim/join_test.go
@@ -47,7 +47,7 @@ func (s *JoinSenderTestSuite) TearDownTest() {
 	s.tnode.Destroy()
 }
 
-func (s *JoinSenderTestSuite) TestSendJoinNoBoostrapHosts() {
+func (s *JoinSenderTestSuite) TestSendJoinNoBootstrapHosts() {
 	joined, err := sendJoin(s.node, nil)
 
 	s.Error(err, "expected error for no bootstrap hosts")

--- a/swim/ping_request_sender.go
+++ b/swim/ping_request_sender.go
@@ -82,6 +82,9 @@ func (p *pingRequestSender) SendPingRequest() (*pingResponse, error) {
 	var res pingResponse
 	select {
 	case err := <-p.MakeCall(ctx, &res):
+		if err == nil {
+			p.node.memberlist.Update(res.Changes)
+		}
 		return &res, err
 
 	case <-ctx.Done(): // call timed out
@@ -112,6 +115,29 @@ func (p *pingRequestSender) MakeCall(ctx json.Context, res *pingResponse) <-chan
 	return errC
 }
 
+// indirectPing is used to check if a target node can be reached indirectly.
+// The indirectPing is performed by sending a specifiable amount of ping
+// requests nodes in n's membership.
+func indirectPing(n *Node, target string, amount int, timeout time.Duration) (reached bool, errs []error) {
+	resCh := sendPingRequests(n, target, amount, timeout)
+
+	// wait for responses from the ping-reqs
+	for result := range resCh {
+		switch res := result.(type) {
+		case *pingResponse:
+			if res.Ok {
+				return true, errs
+			}
+			// If the ping to the target was not-ok we want to wait for more results.
+
+		case error:
+			errs = append(errs, res)
+		}
+	}
+
+	return false, errs
+}
+
 // sendPingRequests sends ping requests to the target address and returns a channel
 //containing the responses. Responses can be one of type:
 //  (1) error:          if the call to peer failed
@@ -137,6 +163,8 @@ func sendPingRequests(node *Node, target string, size int, timeout time.Duration
 		wg.Add(1)
 
 		go func(peer Member) {
+			defer wg.Done()
+
 			p := newPingRequestSender(node, peer.Address, target, timeout)
 
 			p.node.log.WithFields(log.Fields{
@@ -146,19 +174,28 @@ func sendPingRequests(node *Node, target string, size int, timeout time.Duration
 
 			var startTime = time.Now()
 			res, err := p.SendPingRequest()
+
 			if err != nil {
-				resC <- err
-			} else {
-				node.emit(PingRequestsSendCompleteEvent{
-					Local:    node.Address(),
-					Target:   target,
-					Peers:    peerAddresses,
-					Duration: time.Now().Sub(startTime),
+				node.emit(PingRequestSendErrorEvent{
+					Local:  node.Address(),
+					Target: target,
+					Peers:  peerAddresses,
+					Peer:   peer.Address,
 				})
-				resC <- res
+
+				resC <- err
+				return
 			}
 
-			wg.Done()
+			node.emit(PingRequestsSendCompleteEvent{
+				Local:    node.Address(),
+				Target:   target,
+				Peers:    peerAddresses,
+				Peer:     peer.Address,
+				Duration: time.Now().Sub(startTime),
+			})
+
+			resC <- res
 		}(*peer)
 	}
 

--- a/swim/ping_request_test.go
+++ b/swim/ping_request_test.go
@@ -24,8 +24,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber/ringpop-go/events"
 	"github.com/uber/ringpop-go/util"
+	"github.com/uber/tchannel-go"
 )
 
 type PingRequestTestSuite struct {
@@ -118,4 +121,231 @@ func (s *PingRequestTestSuite) TestTimesOut() {
 
 func TestPingRequestTestSuite(t *testing.T) {
 	suite.Run(t, new(PingRequestTestSuite))
+}
+
+// When testing the indirectPing, there are a lot of different ping-req
+// scenarios. There are four identifiable scenarios where the target is
+// reachable:
+// 1. Target is reached by one node and the other node blocks;
+// 2. Target is not-ready for first ping-req, reachable for the second;
+// 3. Target is unreachable for first ping-req, reachable for the second;
+// 4. Connection error to helper node, the second helper reaches the target.
+
+// There are two cases in which the target is definitely not reachable:
+// 5. all ping-reqs report that the target is not-ready;
+// 6. all ping-reqs report that the target in unreachable.
+
+// The indirectPing is said to be inconclusive when all the helper nodes
+// are unreachable.
+// 7. Connection errors from all nodes that perform the pings.
+
+// When the first ping-req with an ok status, the indirectPing
+// immediately returns that it has reached the target. Even though the
+// status of the second ping is unknown.
+func TestIndirectPing1(t *testing.T) {
+	block := make(chan bool)
+
+	tnodes := genChannelNodes(t, 4)
+	defer destroyNodes(tnodes...)
+
+	sender, helper1, helper2, target := tnodes[0], tnodes[1], tnodes[2], tnodes[3]
+	bootstrapNodes(t, sender, helper1, helper2, target)
+	waitForConvergence(t, 500*time.Millisecond, sender, helper1, helper2, target)
+
+	targetHostPort := target.node.Address()
+
+	// block one ping-req indefinitely
+	helper1.node.RegisterListener(onPingRequestReceive(func() {
+		<-block
+	}))
+
+	reached, errs := indirectPing(sender.node, targetHostPort, 2, time.Second)
+	assert.True(t, reached, "expected that target is reached")
+	assert.Len(t, errs, 0, "expected no errors from the helper nodes")
+	close(block)
+}
+
+// First ping the target while it is not-ready, on second ping the
+// target is bootstrapped, and the ping-req reports with an ok status.
+// The indirectPing returns that it has reached the target.
+func TestIndirectPing2(t *testing.T) {
+	cont := make(chan bool, 1)
+
+	tnodes := genChannelNodes(t, 4)
+	defer destroyNodes(tnodes...)
+
+	// don't bootstrap the target
+	sender, helper1, helper2, target := tnodes[0], tnodes[1], tnodes[2], tnodes[3]
+	bootstrapNodes(t, sender, helper1, helper2)
+	waitForConvergence(t, 500*time.Millisecond, sender, helper1, helper2)
+
+	tnodes = append(tnodes, newChannelNode(t))
+	targetHostPort := target.node.Address()
+
+	// block ping-req until first ping-req is done
+	helper1.node.RegisterListener(onPingRequestReceive(func() {
+		<-cont
+	}))
+
+	// bootstrap node and then unblock second ping-req
+	sender.node.RegisterListener(onPingRequestComplete(func() {
+		// bootstrap target node
+		bootstrapNodes(t, sender, helper1, helper2, target)
+		cont <- true
+	}))
+
+	reached, errs := indirectPing(sender.node, targetHostPort, 2, time.Second)
+	assert.True(t, reached, "expected that target is reached")
+	assert.Len(t, errs, 0, "expected no errors from the helper nodes")
+}
+
+// First ping the target while it responds with a tchannel error.
+// On the second ping the target is bootstrapped and the ping-req reports with
+// an ok status. The indirectPing returns that it has reached the target
+func TestIndirectPing3(t *testing.T) {
+	cont := make(chan bool, 1)
+
+	tnodes := genChannelNodes(t, 4)
+	defer destroyNodes(tnodes...)
+
+	// don't create target yet
+	sender, helper1, helper2 := tnodes[0], tnodes[1], tnodes[2]
+	bootstrapNodes(t, sender, helper1, helper2)
+	waitForConvergence(t, 500*time.Millisecond, sender, helper1, helper2)
+
+	ch, err := tchannel.NewChannel("test", nil)
+	assert.NoError(t, err, "expected to setup tchannel")
+	err = ch.ListenAndServe("127.0.0.1:0")
+	assert.NoError(t, err, "expected to listen on channel")
+	targetHostPort := ch.PeerInfo().HostPort
+
+	// block ping-req until first ping-req is done
+	helper1.node.RegisterListener(onPingRequestReceive(func() {
+		<-cont
+	}))
+
+	// initialize target and unblock second ping-req
+	sender.node.RegisterListener(onPingRequestComplete(func() {
+		// create and add target to cluster
+		targetNode := NewNode("test", targetHostPort, ch.GetSubChannel("test"), nil)
+		target := &testNode{targetNode, ch}
+		tnodes = append(tnodes, target)
+		bootstrapNodes(t, sender, helper1, helper2, target)
+		cont <- true
+	}))
+
+	reached, errs := indirectPing(sender.node, targetHostPort, 2, time.Second)
+	assert.True(t, reached, "expected that target is reached")
+	assert.Len(t, errs, 0, "expected no errors from the helper nodes")
+}
+
+// The first ping-req doesn't reach the helper node. The second ping-req
+// does and the ping reached the target. The indirectPing therefore returns
+// that it has successfully reached the target.
+func TestIndirectPing4(t *testing.T) {
+	cont := make(chan bool, 1)
+
+	tnodes := genChannelNodes(t, 4)
+	defer destroyNodes(tnodes...)
+
+	sender, helper1, helper2, target := tnodes[0], tnodes[1], tnodes[2], tnodes[3]
+	bootstrapNodes(t, sender, helper1, helper2, target)
+	waitForConvergence(t, 500*time.Millisecond, sender, helper1, helper2, target)
+
+	targetHostPort := target.node.Address()
+
+	helper2.closeAndWait(sender.channel)
+
+	// block ping-req of healthy node
+	helper1.node.RegisterListener(onPingRequestReceive(func() {
+		<-cont
+	}))
+
+	// first ping-req has failed because helper2 is closed, unblock second ping-req
+	sender.node.RegisterListener(onPingRequestComplete(func() {
+		cont <- true
+	}))
+
+	reached, errs := indirectPing(sender.node, targetHostPort, 2, time.Second)
+	assert.True(t, reached, "expected that target is reached")
+	assert.Len(t, errs, 1, "expected one connection error from the helper nodes")
+}
+
+// Test where target is not bootstrapped and responds with not-readies,
+// indirectPing cannot reach the target and returns false.
+func TestIndirectPing5(t *testing.T) {
+	tnodes := genChannelNodes(t, 4)
+	defer destroyNodes(tnodes...)
+
+	// don't bootstrap the target
+	sender, helper1, helper2, target := tnodes[0], tnodes[1], tnodes[2], tnodes[3]
+	bootstrapNodes(t, sender, helper1, helper2)
+	waitForConvergence(t, 500*time.Millisecond, sender, helper1, helper2)
+
+	// Add an bootstrapped node.
+	targetHostPort := target.node.Address()
+
+	reached, errs := indirectPing(sender.node, targetHostPort, 2, time.Second)
+	assert.False(t, reached, "expected that target is unreachable")
+	assert.Len(t, errs, 0, "expected no errors from the helper nodes")
+}
+
+// Test where target node is unreachable, indirectPing is negative and
+// returns false.
+func TestIndirectPing6(t *testing.T) {
+	tnodes := genChannelNodes(t, 4)
+	defer destroyNodes(tnodes...)
+
+	sender, helper1, helper2, target := tnodes[0], tnodes[1], tnodes[2], tnodes[3]
+	bootstrapNodes(t, sender, helper1, helper2, target)
+	waitForConvergence(t, 500*time.Millisecond, sender, helper1, helper2, target)
+
+	targetHostPort := target.node.Address()
+	target.closeAndWait(sender.channel)
+
+	reached, errs := indirectPing(sender.node, targetHostPort, 2, time.Second)
+	assert.False(t, reached, "expected that target is not reached")
+	assert.Len(t, errs, 0, "expected no errors from the helper nodes")
+}
+
+// Test where helper nodes are unreachable, indirectPing is inconclusive
+// and returns false to indicate that the target hasn't been reached.
+func TestIndirectPing7(t *testing.T) {
+	tnodes := genChannelNodes(t, 4)
+	defer destroyNodes(tnodes...)
+
+	bootstrapNodes(t, tnodes...)
+	waitForConvergence(t, 500*time.Millisecond, tnodes...)
+	sender, helper1, helper2, target := tnodes[0], tnodes[1], tnodes[2], tnodes[3]
+
+	targetHostPort := target.node.Address()
+	helper1.closeAndWait(sender.channel)
+	helper2.closeAndWait(sender.channel)
+
+	reached, errs := indirectPing(sender.node, targetHostPort, 2, time.Second)
+	assert.False(t, reached, "expected that target is unreachable")
+	assert.Len(t, errs, 2, "expected only errors from the helper nodes")
+}
+
+// onPingRequestComplete can be registered on an EventListener and fires the
+// specified function only when the PingRequestSender receives a response or
+// error.
+func onPingRequestComplete(f func()) ListenerFunc {
+	return ListenerFunc(func(e events.Event) {
+		switch e.(type) {
+		case PingRequestsSendCompleteEvent, PingRequestSendErrorEvent:
+			f()
+		}
+	})
+}
+
+// onPingRequestReceive can be registered on an EventListener and fires f only
+// when the PingRequest handler receives a request.
+func onPingRequestReceive(f func()) ListenerFunc {
+	return ListenerFunc(func(e events.Event) {
+		switch e.(type) {
+		case PingRequestReceiveEvent:
+			f()
+		}
+	})
 }


### PR DESCRIPTION
Restructure ping-reqs and put them into a indirectPing -> (reached bool, errs []errors) function
The test is said to be inconclusive if **all** nodes that should ping the target are unreachable.

Add tests for all seven possible ping-req scenarios.

Add a ListenerFunc type to the swim/events.go that turns a function into a object that implements EventListener.
