### PR TITLE
Ensure non-zero exit on compile fail

### DIFF
--- a/test/go-test-prettify
+++ b/test/go-test-prettify
@@ -68,7 +68,7 @@ echo "# tests: $run"
 [ $skipped -ne 0 ] && echo "# skipped: $skipped"
 echo
 
-# Exit with non-zero code if there were test errors
-if [ $failed -ne 0 ]; then
+# Exit with non-zero code if there were test or compile errors
+if [ $failed -ne 0 -o $run -eq 0 ]; then
 	exit 1
 fi


### PR DESCRIPTION
This fixes an issue where tests with import errors were passing because
the number of failed tests was equal to 0 (because no tests ran).

@uber/ringpop 