### PR TITLE
Ws defensive piggybacking

### DIFF
--- a/swim/disseminator_test.go
+++ b/swim/disseminator_test.go
@@ -75,41 +75,97 @@ func (s *DisseminatorTestSuite) TestFullSync() {
 func (s *DisseminatorTestSuite) TestIssueChangesAsSender() {
 	s.d.ClearChanges()
 
-	s.m.MakeAlive("127.0.0.1:3002", s.incarnation)
-	s.m.MakeSuspect("127.0.0.1:3003", s.incarnation)
-	s.m.MakeFaulty("127.0.0.1:3004", s.incarnation)
+	aliveAddr := "127.0.0.1:3002"
+	suspectAddr := "127.0.0.1:3003"
+	faultyAddr := "127.0.0.1:3004"
+	s.m.MakeAlive(aliveAddr, s.incarnation)
+	s.m.MakeSuspect(suspectAddr, s.incarnation)
+	s.m.MakeFaulty(faultyAddr, s.incarnation)
 
-	changes := s.d.IssueAsSender()
+	changes, _ := s.d.IssueAsSender()
 	s.Len(changes, 3, "expected three changes to be issued")
 }
 
 func (s *DisseminatorTestSuite) TestIssueChangesAsReceiver() {
 	s.d.ClearChanges()
 
-	s.m.MakeAlive("127.0.0.1:3002", s.incarnation)
-	s.m.MakeSuspect("127.0.0.1:3003", s.incarnation)
-	s.m.MakeFaulty("127.0.0.1:3004", s.incarnation)
+	aliveAddr := "127.0.0.1:3002"
+	suspectAddr := "127.0.0.1:3003"
+	faultyAddr := "127.0.0.1:3004"
+	s.m.MakeAlive(aliveAddr, s.incarnation)
+	s.m.MakeSuspect(suspectAddr, s.incarnation)
+	s.m.MakeFaulty(faultyAddr, s.incarnation)
 
 	changes, fs := s.d.IssueAsReceiver(s.node.Address(), s.node.Incarnation(), s.m.Checksum())
 	s.Len(changes, 0, "expected no changes to be issued for same sender/receiver")
 	s.False(fs, "expected changes to not be a full sync")
 
-	changes, fs = s.d.IssueAsReceiver("127.0.0.1:3002", s.incarnation, s.m.Checksum())
+	changes, fs = s.d.IssueAsReceiver(aliveAddr, s.incarnation, s.m.Checksum())
 	s.Len(changes, 3, "expected three changes to be issued")
 	s.False(fs, "expected changes to not be a full sync")
 
 	s.d.ClearChanges()
 
-	changes, fs = s.d.IssueAsReceiver("127.0.0.1:3002", s.incarnation, s.m.Checksum())
+	changes, fs = s.d.IssueAsReceiver(aliveAddr, s.incarnation, s.m.Checksum())
 	s.Len(changes, 0, "expected to get no changes")
 	s.False(fs, "expected changes to not be a full sync")
 
-	changes, fs = s.d.IssueAsReceiver("127.0.0.1:3002", s.incarnation, s.m.Checksum()+1)
+	changes, fs = s.d.IssueAsReceiver(aliveAddr, s.incarnation, s.m.Checksum()+1)
 	s.Len(changes, 4, "expected change to be issued for each member in membership")
 	s.True(fs, "expected changes to be a full sync")
 }
 
-func (s *DisseminatorTestSuite) TestChangesDeleted() {
+func (s *DisseminatorTestSuite) TestBumpPiggybackAsSender() {
+	s.d.ClearChanges()
+
+	aliveAddr := "127.0.0.1:3002"
+	suspectAddr := "127.0.0.1:3003"
+	faultyAddr := "127.0.0.1:3004"
+	s.m.MakeAlive(aliveAddr, s.incarnation)
+	s.m.MakeSuspect(suspectAddr, s.incarnation)
+	s.m.MakeFaulty(faultyAddr, s.incarnation)
+	ac := s.d.changes[aliveAddr]
+	sc := s.d.changes[suspectAddr]
+	fc := s.d.changes[faultyAddr]
+
+	s.Equal(ac.p, 0, "expected piggyback counter isn't bumped")
+	s.Equal(sc.p, 0, "expected piggyback counter isn't bumped")
+	s.Equal(fc.p, 0, "expected piggyback counter isn't bumped")
+
+	_, bumpPiggybackCounters := s.d.IssueAsSender()
+	s.Equal(ac.p, 0, "expected piggyback counter isn't bumped")
+	s.Equal(sc.p, 0, "expected piggyback counter isn't bumped")
+	s.Equal(fc.p, 0, "expected piggyback counter isn't bumped")
+	bumpPiggybackCounters()
+	s.Equal(ac.p, 1, "expected piggyback counter is bumped")
+	s.Equal(sc.p, 1, "expected piggyback counter is bumped")
+	s.Equal(fc.p, 1, "expected piggyback counter is bumped")
+}
+
+func (s *DisseminatorTestSuite) TestBumpPiggybackAsReceiver() {
+	s.d.ClearChanges()
+
+	aliveAddr := "127.0.0.1:3002"
+	suspectAddr := "127.0.0.1:3003"
+	faultyAddr := "127.0.0.1:3004"
+	s.m.MakeAlive(aliveAddr, s.incarnation)
+	s.m.MakeSuspect(suspectAddr, s.incarnation)
+	s.m.MakeFaulty(faultyAddr, s.incarnation)
+	ac := s.d.changes[aliveAddr]
+	sc := s.d.changes[suspectAddr]
+	fc := s.d.changes[faultyAddr]
+
+	s.Equal(ac.p, 0, "expected piggyback counter isn't bumped")
+	s.Equal(sc.p, 0, "expected piggyback counter isn't bumped")
+	s.Equal(fc.p, 0, "expected piggyback counter isn't bumped")
+
+	_, _ = s.d.IssueAsReceiver(aliveAddr, s.incarnation, s.m.Checksum())
+	s.Equal(ac.p, 1, "expected piggyback counter is bumped")
+	s.Equal(sc.p, 1, "expected piggyback counter is bumped")
+	s.Equal(fc.p, 1, "expected piggyback counter is bumped")
+}
+
+func (s *DisseminatorTestSuite) TestChangesDeletedAsSender() {
 	s.d.ClearChanges()
 	s.d.maxP = 2
 	s.d.pFactor = 2
@@ -120,19 +176,132 @@ func (s *DisseminatorTestSuite) TestChangesDeleted() {
 
 	s.Equal(0, s.d.changes[address].p, "expected propagations for change to be 0")
 
-	changes := s.d.IssueAsSender()
+	changes, bumpPiggybackCounters := s.d.IssueAsSender()
+	oldBumpPBC := bumpPiggybackCounters
+	bumpPiggybackCounters()
 	s.Len(changes, 1, "expected one change to be issued")
 	s.Equal(1, s.d.changes[address].p, "expected propagations for change to be 1")
 
-	changes = s.d.IssueAsSender()
+	changes, bumpPiggybackCounters = s.d.IssueAsSender()
+	bumpPiggybackCounters()
 	s.Len(changes, 1, "expected one change to be issued")
-	s.Equal(2, s.d.changes[address].p, "expected propagations for change to be 2")
+	s.Empty(s.d.changes, "expected changes are cleared after 2 propagations")
 
-	changes = s.d.IssueAsSender()
+	changes, bumpPiggybackCounters = s.d.IssueAsSender()
+	bumpPiggybackCounters()
+	s.Empty(changes, "expected no changes to be issued")
+	s.Empty(s.d.changes, "expected changes are cleared after 2 propagations")
+
+	_, ok := s.d.changes[address]
+	s.False(ok, "expected change to be deleted")
+
+	// make sure bumping pb counters of removed changes is ok
+	oldBumpPBC()
+	s.Empty(s.d.changes, "expected changes are cleared after 2 propagations")
+}
+
+func (s *DisseminatorTestSuite) TestChangesDeletedAsReceiver() {
+	s.d.ClearChanges()
+	s.d.maxP = 2
+	s.d.pFactor = 2
+
+	address := "127.0.0.1:3002"
+
+	s.m.MakeAlive(address, s.incarnation)
+
+	s.Equal(0, s.d.changes[address].p, "expected propagations for change to be 0")
+
+	changes, _ := s.d.IssueAsReceiver(address, s.incarnation, s.m.Checksum())
+	s.Len(changes, 1, "expected one change to be issued")
+	s.Equal(1, s.d.changes[address].p, "expected propagations for change to be 1")
+
+	changes, _ = s.d.IssueAsReceiver(address, s.incarnation, s.m.Checksum())
+	s.Len(changes, 1, "expected one change to be issued")
+	s.Empty(s.d.changes, "expected changes are cleared after 2 propagations")
+
+	changes, _ = s.d.IssueAsReceiver(address, s.incarnation, s.m.Checksum())
 	s.Empty(changes, "expected no changes to be issued")
 
 	_, ok := s.d.changes[address]
 	s.False(ok, "expected change to be deleted")
+}
+
+func (s *DisseminatorTestSuite) TestFilterChangesFromSender() {
+	s.d.ClearChanges()
+	aliveAddr := "127.0.0.1:3002"
+	suspectAddr := "127.0.0.1:3003"
+	faultyAddr := "127.0.0.1:3004"
+	s.m.MakeAlive(aliveAddr, s.incarnation)
+	s.m.MakeSuspect(suspectAddr, s.incarnation)
+	s.m.MakeFaulty(faultyAddr, s.incarnation)
+
+	// make aliveAddr the source of suspect change
+	s.d.changes[suspectAddr].Source = aliveAddr
+	s.d.changes[suspectAddr].Incarnation = s.incarnation
+
+	changes := s.d.issueChanges()
+	s.Len(changes, 3, "expected three changes")
+
+	cs1 := s.d.filterChangesFromSender(changes, aliveAddr, s.incarnation)
+
+	// test that filterChangesFromSender only reorders but not modifies otherwise
+	s.Len(changes, 3, "expected that changes is reordered but not shrunk")
+	s.True(contains(changes, aliveAddr), "expected that changes is reordered correctly")
+	s.True(contains(changes, suspectAddr), "expected that changes is reordered correctly")
+	s.True(contains(changes, faultyAddr), "expected that changes is reordered correctly")
+
+	// test that one change is filtered for aliveAddr
+	s.Len(cs1, 2, "expected one change was filtered")
+	s.True(contains(cs1, aliveAddr), "expected that alive change is not filtered")
+	s.True(contains(cs1, faultyAddr), "expected that faulty change is not filtered")
+	s.False(contains(cs1, suspectAddr), "expected that suspect change filtered")
+
+	// test that two changes are filtered for local address
+	cs1 = s.d.filterChangesFromSender(changes, s.d.node.Address(), s.d.node.Incarnation())
+	s.Len(cs1, 1, "expected two changes were filtered")
+	s.True(contains(cs1, suspectAddr), "expected that suspect change is not filtered")
+	s.False(contains(cs1, aliveAddr), "expected that alive change is filtered")
+	s.False(contains(cs1, faultyAddr), "expected that faulty change is filtered")
+
+	// test that no changes are filtered when incarnation number doesn't match
+	cs1 = s.d.filterChangesFromSender(changes, aliveAddr, s.incarnation-1)
+	s.Len(cs1, 3, "expected no changes were filtered")
+	s.True(contains(cs1, aliveAddr), "expected no nodes were filtered")
+	s.True(contains(cs1, suspectAddr), "expected no nodes were filtered")
+	s.True(contains(cs1, faultyAddr), "expected no nodes were filtered")
+
+	// test that no changes are filtered when for suspectAddr
+	cs1 = s.d.filterChangesFromSender(changes, suspectAddr, s.incarnation)
+	s.Len(cs1, 3, "expected no changes were filtered")
+	s.True(contains(cs1, aliveAddr), "expected no nodes were filtered")
+	s.True(contains(cs1, suspectAddr), "expected no nodes were filtered")
+	s.True(contains(cs1, faultyAddr), "expected no nodes were filtered")
+
+	// test that no changes are filtered when for aliveAddr
+	cs1 = s.d.filterChangesFromSender(changes, faultyAddr, s.incarnation)
+	s.Len(cs1, 3, "expected no changes were filtered")
+	s.True(contains(cs1, aliveAddr), "expected no nodes were filtered")
+	s.True(contains(cs1, suspectAddr), "expected no nodes were filtered")
+	s.True(contains(cs1, faultyAddr), "expected no nodes were filtered")
+
+	// make change the source of suspect change back to local address
+	s.d.changes[suspectAddr].Source = s.d.node.Address()
+	s.d.changes[suspectAddr].Incarnation = s.d.node.Incarnation()
+
+	// test all changes are filtered
+	changes = s.d.issueChanges()
+	cs1 = s.d.filterChangesFromSender(changes, s.d.node.Address(), s.d.node.Incarnation())
+	s.Len(changes, 3, "expected changes is reodered but not shrunk")
+	s.Len(cs1, 0, "expected all changes were filtered")
+}
+
+func contains(cs []Change, address string) bool {
+	for _, c := range cs {
+		if c.address() == address {
+			return true
+		}
+	}
+	return false
 }
 
 func TestDisseminatorTestSuite(t *testing.T) {

--- a/swim/handlers_test.go
+++ b/swim/handlers_test.go
@@ -189,12 +189,20 @@ func (s *HandlerTestSuite) TestJoinHandlerError() {
 
 func (s *HandlerTestSuite) TestPingRequestHandler() {
 	// Bootstrap the test node, so it's ready to receive pings
-	s.testNode.node.Bootstrap(&BootstrapOptions{
-		DiscoverProvider: &StaticHostList{[]string{s.testNode.node.Address()}},
+	node := s.testNode.node
+	node.Bootstrap(&BootstrapOptions{
+		DiscoverProvider: &StaticHostList{[]string{node.Address()}},
 	})
 
-	req := newPingRequest(s.testNode.node, s.testNode.node.Address())
-	res, err := s.testNode.node.pingRequestHandler(s.ctx, req)
+	req := &pingRequest{
+		Source:            node.Address(),
+		SourceIncarnation: node.Incarnation(),
+		Checksum:          node.memberlist.Checksum(),
+		Changes:           nil,
+		Target:            node.Address(),
+	}
+
+	res, err := node.pingRequestHandler(s.ctx, req)
 
 	s.NoError(err)
 	s.True(res.Ok, "expected ok response from ping")
@@ -202,8 +210,16 @@ func (s *HandlerTestSuite) TestPingRequestHandler() {
 
 func (s *HandlerTestSuite) TestPingRequestHandlerFail() {
 	// Node is not ready to receive pings when it's not bootstrapped
-	req := newPingRequest(s.testNode.node, s.testNode.node.Address())
-	res, err := s.testNode.node.pingRequestHandler(s.ctx, req)
+	node := s.testNode.node
+	req := &pingRequest{
+		Source:            node.Address(),
+		SourceIncarnation: node.Incarnation(),
+		Checksum:          node.memberlist.Checksum(),
+		Changes:           nil,
+		Target:            node.Address(),
+	}
+
+	res, err := node.pingRequestHandler(s.ctx, req)
 
 	s.Error(err)
 	s.Nil(res)

--- a/swim/ping_handler.go
+++ b/swim/ping_handler.go
@@ -37,10 +37,11 @@ func handlePing(node *Node, req *ping) (*ping, error) {
 
 	node.memberlist.Update(req.Changes)
 
-	changes, fs := node.disseminator.IssueAsReceiver(req.Source, req.SourceIncarnation, req.Checksum)
+	changes, fullSync :=
+		node.disseminator.IssueAsReceiver(req.Source, req.SourceIncarnation, req.Checksum)
 
-	if fs {
-		// TODO: something...
+	if fullSync {
+		// TODO: handle full sync
 	}
 
 	res := &ping{

--- a/swim/ping_sender.go
+++ b/swim/ping_sender.go
@@ -85,9 +85,10 @@ func (p *pingSender) MakeCall(ctx json.Context, res *ping) <-chan error {
 
 		peer := p.node.channel.Peers().GetOrAdd(p.target)
 
+		changes, bumpPiggybackCounters := p.node.disseminator.IssueAsSender()
 		req := ping{
 			Checksum:          p.node.memberlist.Checksum(),
-			Changes:           p.node.disseminator.IssueAsSender(),
+			Changes:           changes,
 			Source:            p.node.Address(),
 			SourceIncarnation: p.node.Incarnation(),
 		}
@@ -114,6 +115,9 @@ func (p *pingSender) MakeCall(ctx json.Context, res *ping) <-chan error {
 			errC <- err
 			return
 		}
+
+		// when ping was successful
+		bumpPiggybackCounters()
 
 		p.node.emit(PingSendCompleteEvent{
 			Local:    p.node.Address(),


### PR DESCRIPTION
Three commits, I recommend looking at them separately.

1. Removes the bumping of piggyback counters out of issueChange function. IssueAsSender now returns a callback that raises the pb counters, this callback is supposed to be called when the ping or ping-req has succeeded. IssueAsReceiver now increments the pb counters when called, because it is not easy to find out wether a response will reach the client.

2. Removes newPingRequest and just use the literal expression &pingRequest{...}

3. Removes filter from issueChanges because it was only used in issueAsReceiver and added a lot of unnecessary complexity.
