### PR TITLE
Add test for error on bootstrap

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,13 @@ package ringpop
 
 import "errors"
 
-// ErrNotBootstrapped is returned by public methods which require the ring to
-// be bootstrapped before they can operate correctly.
-var ErrNotBootstrapped = errors.New("ringpop is not bootstrapped")
+var (
+	// ErrNotBootstrapped is returned by public methods which require the ring to
+	// be bootstrapped before they can operate correctly.
+	ErrNotBootstrapped = errors.New("ringpop is not bootstrapped")
+
+	// ErrEphemeralIdentity is returned by the identity resolver if TChannel is
+	// using port 0 and is not listening (and thus has not been assigned a port by
+	// the OS).
+	ErrEphemeralIdentity = errors.New("unable to resolve this node's identity from channel that is not yet listening")
+)

--- a/ringpop.go
+++ b/ringpop.go
@@ -187,15 +187,16 @@ func (rp *Ringpop) identity() (string, error) {
 // r.channelIdentityResolver resolves the hostport identity from the current
 // TChannel object on the Ringpop instance.
 func (rp *Ringpop) channelIdentityResolver() (string, error) {
-	hostport := rp.channel.PeerInfo().HostPort
-	// Check that TChannel is listening. By default, TChannel listens on an
-	// ephemeral host/port. The real port is then assigned by the OS when
-	// ListenAndServe is called. If the hostport is 0.0.0.0:0, it means
-	// TChannel is not yet listening and the hostport cannot be resolved.
-	if hostport == "0.0.0.0:0" {
-		return "", fmt.Errorf("unable to resolve valid listen address (TChannel hostport is %s)", hostport)
+	peerInfo := rp.channel.PeerInfo()
+	// Check that TChannel is listening on a real hostport. By default,
+	// TChannel listens on an ephemeral host/port. The real port is then
+	// assigned by the OS when ListenAndServe is called. If the hostport is
+	// ephemeral, it means TChannel is not yet listening and the hostport
+	// cannot be resolved.
+	if peerInfo.IsEphemeralHostPort() {
+		return "", ErrEphemeralIdentity
 	}
-	return hostport, nil
+	return peerInfo.HostPort, nil
 }
 
 // Destroy stops all communication. Note that this does not close the TChannel

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -549,6 +549,18 @@ func (s *RingpopTestSuite) TestEmptyJoinListCreatesSingleNodeCluster() {
 	s.Equal(ready, s.ringpop.state)
 }
 
+func (s *RingpopTestSuite) TestErrorOnChannelNotListening() {
+	ch, err := tchannel.NewChannel("test", nil)
+	s.Require().NoError(err)
+
+	rp, err := New("test", Channel(ch))
+	s.Require().NoError(err)
+
+	nodesJoined, err := rp.Bootstrap(&swim.BootstrapOptions{})
+	s.Error(err)
+	s.Nil(nodesJoined)
+}
+
 func TestRingpopTestSuite(t *testing.T) {
 	suite.Run(t, new(RingpopTestSuite))
 }

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -557,7 +557,7 @@ func (s *RingpopTestSuite) TestErrorOnChannelNotListening() {
 	s.Require().NoError(err)
 
 	nodesJoined, err := rp.Bootstrap(&swim.BootstrapOptions{})
-	s.Error(err)
+	s.Exactly(err, ErrEphemeralIdentity)
 	s.Nil(nodesJoined)
 }
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -23,7 +23,6 @@ package ringpop
 import (
 	"fmt"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/uber-common/bark"
@@ -70,16 +69,6 @@ func (d *dummyListener) HandleEvent(event events.Event) {
 	d.l.Lock()
 	d.events++
 	d.l.Unlock()
-}
-
-func testPop(t *testing.T, hostport string) (*Ringpop, func()) {
-	ringpop, _ := New("test-app")
-
-	destroy := func() {
-		ringpop.Destroy()
-	}
-
-	return ringpop, destroy
 }
 
 func genAddresses(host, fromPort, toPort int) []string {


### PR DESCRIPTION
Also remove testPop as it's not used.

Cause... why not `¯\_(ツ)_/¯`

@uber/ringpop 