### PR TITLE
don't disseminate join list

### DIFF
--- a/swim/disseminator.go
+++ b/swim/disseminator.go
@@ -179,3 +179,24 @@ func (d *disseminator) RecordChange(change Change) {
 	d.changes[change.Address] = &pChange{change, 0}
 	d.Unlock()
 }
+
+func (d *disseminator) ClearChange(c Change) {
+	d.Lock()
+	delete(d.changes, c.Address)
+	d.Unlock()
+}
+
+func (d *disseminator) ChangeByAddress(address string) (Change, bool) {
+	d.Lock()
+	pc, ok := d.changes[address]
+	c := pc.Change
+	d.Unlock()
+	return c, ok
+}
+
+func (d *disseminator) ChangeCount() int {
+	d.Lock()
+	c := len(d.changes)
+	d.Unlock()
+	return c
+}

--- a/swim/disseminator.go
+++ b/swim/disseminator.go
@@ -186,20 +186,20 @@ func (d *disseminator) ClearChange(c Change) {
 	d.Unlock()
 }
 
-func (d *disseminator) ChangeByAddress(address string) (Change, bool) {
-	d.Lock()
-	pc, ok := d.changes[address]
+func (d *disseminator) ChangesByAddress(address string) (Change, bool) {
+	d.RLock()
+	change, ok := d.changes[address]
 	var c Change
 	if ok {
-		c = pc.Change
+		c = change.Change
 	}
-	d.Unlock()
+	d.RUnlock()
 	return c, ok
 }
 
-func (d *disseminator) ChangeCount() int {
-	d.Lock()
+func (d *disseminator) ChangesCount() int {
+	d.RLock()
 	c := len(d.changes)
-	d.Unlock()
+	d.RUnlock()
 	return c
 }

--- a/swim/disseminator.go
+++ b/swim/disseminator.go
@@ -189,7 +189,10 @@ func (d *disseminator) ClearChange(c Change) {
 func (d *disseminator) ChangeByAddress(address string) (Change, bool) {
 	d.Lock()
 	pc, ok := d.changes[address]
-	c := pc.Change
+	var c Change
+	if ok {
+		c = pc.Change
+	}
 	d.Unlock()
 	return c, ok
 }

--- a/swim/disseminator_test.go
+++ b/swim/disseminator_test.go
@@ -60,27 +60,27 @@ func (s *DisseminatorTestSuite) TestChangesAreRecorded() {
 	s.Len(s.d.changes, 4, "expected four changes to be recorded")
 }
 
-func (s *DisseminatorTestSuite) TestChangeCount() {
+func (s *DisseminatorTestSuite) TestChangesCount() {
 	addresses := fakeHostPorts(1, 1, 2, 4)
 	for i, address := range addresses {
-		s.Equal(i+1, s.d.ChangeCount(), "expected change to be recorded")
+		s.Equal(i+1, s.d.ChangesCount(), "expected change to be recorded")
 
 		s.m.MakeAlive(address, s.incarnation)
 	}
-	s.Equal(len(addresses)+1, s.d.ChangeCount(), "expected no changes to be recorded")
+	s.Equal(len(addresses)+1, s.d.ChangesCount(), "expected no changes to be recorded")
 }
 
-func (s *DisseminatorTestSuite) TestChangeByAddress() {
+func (s *DisseminatorTestSuite) TestChangesByAddress() {
 	addresses := fakeHostPorts(1, 1, 2, 4)
 
-	c, ok := s.d.ChangeByAddress(addresses[0])
+	c, ok := s.d.ChangesByAddress(addresses[0])
 	s.False(ok, "expected changes does not contain this address yet")
 	s.Equal(Change{}, c, "expected change is nil")
 
 	for _, address := range addresses {
 		s.m.MakeAlive(address, s.incarnation)
 
-		c, ok := s.d.ChangeByAddress(address)
+		c, ok := s.d.ChangesByAddress(address)
 		s.True(ok, "expected changes contains this address")
 		s.Equal(address, c.address(), "expected change has correct address")
 		s.Equal(s.incarnation, c.incarnation(), "expected change has correct incarnation")
@@ -96,17 +96,17 @@ func (s *DisseminatorTestSuite) TestChangesAreCleared() {
 	fakeChange := Change{}
 	fakeChange.Address = "fake address"
 	s.d.ClearChange(fakeChange)
-	s.Equal(4, s.d.ChangeCount(), "expected no problems deleting non-existent changes")
+	s.Equal(4, s.d.ChangesCount(), "expected no problems deleting non-existent changes")
 
 	changes := s.d.issueChanges(nil)
 	for i, c := range changes {
 		s.d.ClearChange(c)
-		s.Equal(4-i-1, s.d.ChangeCount(), "expected one change to be deleted")
+		s.Equal(4-i-1, s.d.ChangesCount(), "expected one change to be deleted")
 	}
-	s.Equal(0, s.d.ChangeCount(), "expected no change left")
+	s.Equal(0, s.d.ChangesCount(), "expected no change left")
 
 	s.d.ClearChange(fakeChange)
-	s.Equal(0, s.d.ChangeCount(), "expected no problems deleting non-existent changes")
+	s.Equal(0, s.d.ChangesCount(), "expected no problems deleting non-existent changes")
 }
 
 func (s *DisseminatorTestSuite) TestFullSync() {

--- a/swim/disseminator_test.go
+++ b/swim/disseminator_test.go
@@ -60,6 +60,33 @@ func (s *DisseminatorTestSuite) TestChangesAreRecorded() {
 	s.Len(s.d.changes, 4, "expected four changes to be recorded")
 }
 
+func (s *DisseminatorTestSuite) TestChangeCount() {
+	addresses := fakeHostPorts(1, 1, 2, 4)
+	for i, address := range addresses {
+		s.Equal(i+1, s.d.ChangeCount(), "expected change to be recorded")
+
+		s.m.MakeAlive(address, s.incarnation)
+	}
+	s.Equal(len(addresses)+1, s.d.ChangeCount(), "expected no changes to be recorded")
+}
+
+func (s *DisseminatorTestSuite) TestChangeByAddress() {
+	addresses := fakeHostPorts(1, 1, 2, 4)
+
+	c, ok := s.d.ChangeByAddress(addresses[0])
+	s.False(ok, "expected changes does not contain this address yet")
+	s.Equal(Change{}, c, "expected change is nil")
+
+	for _, address := range addresses {
+		s.m.MakeAlive(address, s.incarnation)
+
+		c, ok := s.d.ChangeByAddress(address)
+		s.True(ok, "expected changes contains this address")
+		s.Equal(address, c.address(), "expected change has correct address")
+		s.Equal(s.incarnation, c.incarnation(), "expected change has correct incarnation")
+	}
+}
+
 func (s *DisseminatorTestSuite) TestChangesAreCleared() {
 	addresses := fakeHostPorts(1, 1, 2, 4)
 

--- a/swim/disseminator_test.go
+++ b/swim/disseminator_test.go
@@ -60,6 +60,28 @@ func (s *DisseminatorTestSuite) TestChangesAreRecorded() {
 	s.Len(s.d.changes, 4, "expected four changes to be recorded")
 }
 
+func (s *DisseminatorTestSuite) TestChangesAreCleared() {
+	addresses := fakeHostPorts(1, 1, 2, 4)
+
+	for _, address := range addresses {
+		s.m.MakeAlive(address, s.incarnation)
+	}
+	fakeChange := Change{}
+	fakeChange.Address = "fake address"
+	s.d.ClearChange(fakeChange)
+	s.Equal(4, s.d.ChangeCount(), "expected no problems deleting non-existent changes")
+
+	changes := s.d.issueChanges(nil)
+	for i, c := range changes {
+		s.d.ClearChange(c)
+		s.Equal(4-i-1, s.d.ChangeCount(), "expected one change to be deleted")
+	}
+	s.Equal(0, s.d.ChangeCount(), "expected no change left")
+
+	s.d.ClearChange(fakeChange)
+	s.Equal(0, s.d.ChangeCount(), "expected no problems deleting non-existent changes")
+}
+
 func (s *DisseminatorTestSuite) TestFullSync() {
 	addresses := fakeHostPorts(1, 1, 2, 4)
 

--- a/swim/join_sender.go
+++ b/swim/join_sender.go
@@ -388,7 +388,17 @@ func (j *joinSender) JoinGroup(nodesJoined []string) ([]string, []string) {
 					failed = true
 					break
 				}
+
+				// We add the join list to the membership with the Update
+				// function. However, as a side effect, Update adds changes to
+				// the disseminator as well. Since we don't want to disseminate
+				// the potentially very large join lists, we clear all the
+				// changes from the disseminator, except for the one change
+				// that refers to the make-alive of this node.
 				j.node.memberlist.Update(res.Membership)
+				for _, change := range res.Membership {
+					j.node.disseminator.ClearChange(change)
+				}
 
 			case <-ctx.Done():
 				j.node.log.WithFields(log.Fields{

--- a/swim/join_test.go
+++ b/swim/join_test.go
@@ -219,9 +219,9 @@ func (s *JoinSenderTestSuite) TestDontDisseminateJoinList() {
 
 	for i, tnode := range tnodes {
 		s.Equal(i+1, tnodes[i].node.memberlist.CountReachableMembers(), "expected that next node joined all previous ones")
-		s.Equal(1, tnodes[i].node.disseminator.ChangeCount(), "expected to only disseminate yourself")
+		s.Equal(1, tnodes[i].node.disseminator.ChangesCount(), "expected to only disseminate yourself")
 
-		_, ok := tnodes[i].node.disseminator.ChangeByAddress(tnode.node.Address())
+		_, ok := tnodes[i].node.disseminator.ChangesByAddress(tnode.node.Address())
 		s.True(ok, "expected to only disseminate yourself")
 	}
 }

--- a/swim/join_test.go
+++ b/swim/join_test.go
@@ -212,3 +212,16 @@ func (s *JoinSenderTestSuite) TestCustomDelayer() {
 func TestJoinSenderTestSuite(t *testing.T) {
 	suite.Run(t, new(JoinSenderTestSuite))
 }
+
+func (s *JoinSenderTestSuite) TestDontDisseminateJoinList() {
+	tnodes := genChannelNodes(s.T(), 5)
+	bootstrapNodes(s.T(), tnodes...)
+
+	for i, tnode := range tnodes {
+		s.Equal(i+1, tnodes[i].node.memberlist.CountReachableMembers(), "expected that next node joined all previous ones")
+		s.Equal(1, tnodes[i].node.disseminator.ChangeCount(), "expected to only disseminate yourself")
+
+		_, ok := tnodes[i].node.disseminator.ChangeByAddress(tnode.node.Address())
+		s.True(ok, "expected to only disseminate yourself")
+	}
+}


### PR DESCRIPTION
After join, clear all nonlocal changes from the disseminator