### PR TITLE
Split TestFlushesAfterInterval, remove Timer.sleep

### DIFF
--- a/swim/clock.go
+++ b/swim/clock.go
@@ -27,6 +27,7 @@ import (
 // Clock is the interface that wraps the Now method.
 type Clock interface {
 	Now() time.Time
+	AfterFunc(time.Duration, func()) *time.Timer
 }
 
 // systemClock uses the system time to implement the Clock interface.
@@ -35,6 +36,11 @@ type systemClock struct{}
 // Now returns the current system time.
 func (c systemClock) Now() time.Time {
 	return time.Now()
+}
+
+// Calls f after d time. See time.AfterFunc.
+func (c systemClock) AfterFunc(d time.Duration, f func()) *time.Timer {
+	return time.AfterFunc(d, f)
 }
 
 // NowInMillis is a utility function that call Now on the clock and converts it

--- a/swim/handlers_test.go
+++ b/swim/handlers_test.go
@@ -117,18 +117,25 @@ func (s *HandlerTestSuite) TestAdminLeaveJoinHandlers() {
 	s.Equal(4, s.testNode.node.CountReachableMembers())
 
 	// Test join handler brings it back to 5
-	s.testNode.node.clock = mockClock(time.Now().Add(time.Millisecond))
+	s.testNode.node.clock = mockClock{
+		systemClock: systemClock{},
+		t:           time.Now().Add(time.Millisecond),
+	}
 	status, err = s.testNode.node.adminJoinHandler(s.ctx, &emptyArg{})
 	s.NoError(err, "calling handler should not result in error")
 	s.Equal(&Status{Status: "rejoined"}, status)
 	s.Equal(5, s.testNode.node.CountReachableMembers())
 }
 
-// mockClock implements the Clock interface with a constant Now method.
-type mockClock time.Time
+// mockClock implements the Clock interface with a constant Now and mockable
+// AfterFunc methods.
+type mockClock struct {
+	systemClock
+	t time.Time
+}
 
 // Now returns the time that is stored in the type.
-func (c mockClock) Now() time.Time { return time.Time(c) }
+func (c mockClock) Now() time.Time { return c.t }
 
 // TestRegisterHandlers tests that registerHandler always succeeds.
 func (s *HandlerTestSuite) TestRegisterHandlers() {

--- a/swim/update_rollup.go
+++ b/swim/update_rollup.go
@@ -128,7 +128,7 @@ func (r *updateRollup) RenewFlushTimer() {
 		r.flushTimer.t.Stop()
 	}
 
-	r.flushTimer.t = time.AfterFunc(r.flushInterval, func() {
+	r.flushTimer.t = r.node.clock.AfterFunc(r.flushInterval, func() {
 		r.FlushBuffer()
 		r.RenewFlushTimer()
 	})


### PR DESCRIPTION
TestFlushesAfterInterval flaps on travis-ci due to relying on wall clock.

1. Create TestFlushingEmptiesTheBuffer, which tests FlushBuffer.
2. Remove Timer.sleep from TestFlushesAfterInterval by mocking the timer.