### PR TITLE
Set a better default for maxP and fix maxP value after bootstrap.

### DIFF
--- a/swim/disseminator.go
+++ b/swim/disseminator.go
@@ -30,6 +30,9 @@ import (
 
 var log10 = math.Log(10)
 
+// defaultPFactor is the piggyback factor value, described in the swim paper.
+const defaultPFactor int = 15
+
 // A pChange is a change with a p count representing the number of times the
 // change has been propagated to other nodes.
 type pChange struct {
@@ -57,8 +60,8 @@ func newDisseminator(n *Node) *disseminator {
 	d := &disseminator{
 		node:    n,
 		changes: make(map[string]*pChange),
-		maxP:    1,
-		pFactor: 15,
+		maxP:    defaultPFactor,
+		pFactor: defaultPFactor,
 		logger:  logging.Logger("disseminator").WithField("local", n.Address()),
 	}
 
@@ -66,10 +69,6 @@ func newDisseminator(n *Node) *disseminator {
 }
 
 func (d *disseminator) AdjustMaxPropagations() {
-	if !d.node.Ready() {
-		return
-	}
-
 	d.Lock()
 
 	numPingable := d.node.memberlist.NumPingableMembers()

--- a/swim/node_bootstrap_test.go
+++ b/swim/node_bootstrap_test.go
@@ -195,6 +195,23 @@ func (s *BootstrapTestSuite) TestMalformedJSONFile() {
 	s.Error(err, "invalid character 'T' looking for beginning of value", "should fail to unmarhsal JSON")
 }
 
+func (s *BootstrapTestSuite) TestDisseminationCounterAfterBootstrap() {
+	s.peers = genChannelNodes(s.T(), 10)
+	bootstrapList := bootstrapNodes(s.T(), s.peers...)
+	waitForConvergence(s.T(), 5*time.Second, s.peers...)
+
+	s.Equal(s.node.disseminator.pFactor, s.node.disseminator.maxP, "Initial maxP value should equal pFactor")
+	s.node.Bootstrap(&BootstrapOptions{
+		Hosts:   bootstrapList,
+		Stopped: true,
+	})
+	waitForConvergence(s.T(), 5*time.Second, append(s.peers, s.tnode)...)
+
+	// there are 11 nodes in total, log10(11) rounded up is 2
+	expected := 2 * s.node.disseminator.pFactor
+	s.Equal(expected, s.node.disseminator.maxP, "maxP should be a multiple of pFactor")
+}
+
 func TestBootstrapTestSuite(t *testing.T) {
 	suite.Run(t, new(BootstrapTestSuite))
 }


### PR DESCRIPTION
Two things going on:
* `maxP` should never be lower than 15, considering the math used to adjust it.
* after bootstrap, the initial value for `maxP` doesn't reflect the ring size.