### PR TITLE
Test Go 1.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
+  - 1.6
   - 1.5
 
 before_install:
@@ -17,7 +18,6 @@ env:
   - RUN="make lint"
   - RUN="make test-unit"
   - RUN="make test-integration"
-  - RUN=test/update-coveralls
 
 matrix:
   allow_failures:
@@ -26,3 +26,6 @@ matrix:
 
 script:
   - test/travis
+
+after_success:
+  - test/update-coveralls

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ v0.DEV (to be released)
   `DiscoverProvider` interface #119
 * Ringpop will always assume the current host (`ringpop.node.identity`) is part
   of the cluster. Previously, it was true for only `Host`-based discovery.
+* Add Go 1.6 testing on CI
 
 ### Release notes
 

--- a/scripts/lint/lint-excludes
+++ b/scripts/lint/lint-excludes
@@ -6,3 +6,16 @@
 ./swim/ping_request_sender.go:*: func passes Lock by value: swim.Member
 ./swim/stats_test.go:*: range var member copies Lock: swim.Member
 ./swim/test_utils.go:*: range var expected copies Lock: swim.Member
+# go 1.6 travis - "Lock" is now lowercase "lock":
+./swim/disseminator.go:*: range var member copies lock: swim.Member
+./swim/member.go:*: address passes lock by value: swim.Member
+./swim/member.go:*: incarnation passes lock by value: swim.Member
+./swim/member_test.go:*: newMember returns lock by value: swim.Member
+./swim/member_test.go:*: assignment copies lock value to m: swim.Member
+./swim/member_test.go:*: assignment copies lock value to m: swim.Member
+./swim/memberlist.go:*: Pingable passes lock by value: swim.Member
+./swim/ping_request_sender.go:*: func passes lock by value: swim.Member
+./swim/stats.go:*: assignment copies lock value to (\*s)\[i\]: swim.Member
+./swim/stats.go:*: assignment copies lock value to (\*s)\[j\]: swim.Member
+./swim/stats_test.go:*: range var member copies lock: swim.Member
+./swim/test_utils.go:*: range var expected copies lock: swim.Member

--- a/scripts/lint/lint-warn
+++ b/scripts/lint/lint-warn
@@ -24,16 +24,18 @@ while IFS= read -r line; do
 	IFS=$'\n'
 	for exclude in $lint_exclude_patterns; do
 		if [[ "$line" == $exclude ]]; then
-			buf="WARNING [excluded]: $line"
-			continue
+			buf="WARNING: $line"
+			break
 		fi
 	done
 
-	if [ ! -z "$buf" ]; then
-		echo "$buf"
-	else
-		echo "$line" >&2
+	if [ -z "$buf" ]; then
+		# Print the error
+		echo "ERROR: $line" >&2
 		exit_code=1
+	else
+		# Print the warning
+		echo "$buf"
 	fi
 done
 

--- a/scripts/lint/test/lint-warn.t
+++ b/scripts/lint/test/lint-warn.t
@@ -8,27 +8,27 @@ Test no args returns exit code 1:
 Test lint with only warnings returns 0 exit code:
 
   $  cat "$BASE_DIR"/test/test-lint-ok.log |"$BASE_DIR"/lint-warn "$BASE_DIR"/test/test-excludes
-  WARNING [excluded]: ./swim/member.go:53: address passes Lock by value: swim.Member
-  WARNING [excluded]: ./swim/member.go:57: incarnation passes Lock by value: swim.Member
-  WARNING [excluded]: ./swim/test_utils.go:135: range var expected copies Lock: swim.Member
+  WARNING: ./swim/member.go:53: address passes Lock by value: swim.Member
+  WARNING: ./swim/member.go:57: incarnation passes Lock by value: swim.Member
+  WARNING: ./swim/test_utils.go:135: range var expected copies Lock: swim.Member
 
 
 Test lint with a mix of warnings/errors returns exit code 1:
 
   $  cat "$BASE_DIR"/test/test-lint-mix.log |"$BASE_DIR"/lint-warn "$BASE_DIR"/test/test-excludes
-  ./swim/disseminator.go:107: range var member copies Lock: swim.Member
-  WARNING [excluded]: ./swim/member.go:53: address passes Lock by value: swim.Member
-  WARNING [excluded]: ./swim/member.go:57: incarnation passes Lock by value: swim.Member
-  ./swim/memberlist.go:128: Pingable passes Lock by value: swim.Member
-  ./swim/stats_test.go:101: range var member copies Lock: swim.Member
-  WARNING [excluded]: ./swim/test_utils.go:135: range var expected copies Lock: swim.Member
+  ERROR: ./swim/disseminator.go:107: range var member copies Lock: swim.Member
+  WARNING: ./swim/member.go:53: address passes Lock by value: swim.Member
+  WARNING: ./swim/member.go:57: incarnation passes Lock by value: swim.Member
+  ERROR: ./swim/memberlist.go:128: Pingable passes Lock by value: swim.Member
+  ERROR: ./swim/stats_test.go:101: range var member copies Lock: swim.Member
+  WARNING: ./swim/test_utils.go:135: range var expected copies Lock: swim.Member
   [1]
 
 
 Test lint with only errors returns exit code 1:
 
   $  cat "$BASE_DIR"/test/test-lint-all-fail.log |"$BASE_DIR"/lint-warn "$BASE_DIR"/test/test-excludes
-  ./swim/disseminator.go:107: range var member copies Lock: swim.Member
-  ./swim/memberlist.go:128: Pingable passes Lock by value: swim.Member
-  ./swim/stats_test.go:101: range var member copies Lock: swim.Member
+  ERROR: ./swim/disseminator.go:107: range var member copies Lock: swim.Member
+  ERROR: ./swim/memberlist.go:128: Pingable passes Lock by value: swim.Member
+  ERROR: ./swim/stats_test.go:101: range var member copies Lock: swim.Member
   [1]


### PR DESCRIPTION
This PR adds test runs to Travis on Go 1.6.

Also includes these changes:

* Make the lint errors obviously different to the warnings by prepending the line with "ERROR"
* Adds new lint errors to the exclude/ignore list (all lint errors are related to the same issue though; copying `swim.Member` locks)
* Run the coveralls upload only once after the Travis builds have succeeded
