### PR TITLE
Bugfix: ringpop-admin leave did not work with ringpop-go

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 ringpop-go changes
 ==================
 
+v0.3.1
+------
+
+* Fix `/admin/leave` and `/admin/join` to work with `ringpop-admin`
+
 v0.3.0
 ------
 

--- a/swim/handlers.go
+++ b/swim/handlers.go
@@ -66,8 +66,8 @@ func (n *Node) registerHandlers() error {
 		"/admin/gossip/stop":  n.gossipHandlerStop,
 		"/admin/tick":         n.tickHandler, // Deprecated
 		"/admin/gossip/tick":  n.tickHandler,
-		"/admin/member/leave": n.adminLeaveHandler,
-		"/admin/member/join":  n.adminJoinHandler,
+		"/admin/leave":        n.adminLeaveHandler,
+		"/admin/join":         n.adminJoinHandler,
 	}
 
 	return json.Register(n.channel, handlers, n.errorHandler)


### PR DESCRIPTION
After this patch `ringpop-admin leave` works on ringpop-go applications:

```bash
$ ./partitions.js --ring 172.18.27.113:3000
 Checksum     # Nodes   # Alive   # Suspect   # Faulty   Sample Host
 3473867175   5         5         0           0          172.18.27.113:3000
$ ringpop-admin leave 172.18.27.113:3000
$ ./partitions.js --ring 172.18.27.113:3000
 Checksum    # Nodes   # Alive   # Suspect   # Faulty   Sample Host
 436685835   5         4         0           0          172.18.27.113:3000
$ ringpop-admin join 172.18.27.113:3000
$ ./partitions.js --ring 172.18.27.113:3000
 Checksum     # Nodes   # Alive   # Suspect   # Faulty   Sample Host
 3473867175   5         5         0           0          172.18.27.113:3000
```