### PR TITLE
Reaping Faulty Nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ v0.DEV (to be released)
   `DiscoverProvider` interface #119
 * Ringpop will always assume the current host (`ringpop.node.identity`) is part
   of the cluster. Previously, it was true for only `Host`-based discovery.
+* Implemented reaping of faulty nodes. By default ringpop will remove faulty nodes
+  after 24 hours of being in faulty state.
 
 ### Release notes
 

--- a/options.go
+++ b/options.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber/ringpop-go/hashring"
 	"github.com/uber/ringpop-go/logging"
 	"github.com/uber/ringpop-go/shared"
+	"github.com/uber/ringpop-go/swim"
 )
 
 type configuration struct {
@@ -43,6 +44,9 @@ type configuration struct {
 	// See funcs {Membership,Ring}ChecksumStatPeriod for specifics.
 	MembershipChecksumStatPeriod time.Duration
 	RingChecksumStatPeriod       time.Duration
+
+	// StateTimeouts keeps the state transition timeouts for swim to use
+	StateTimeouts swim.StateTimeouts
 }
 
 // An Option is a modifier functions that configure/modify a real Ringpop
@@ -233,6 +237,45 @@ func RingChecksumStatPeriod(period time.Duration) Option {
 			return errors.New("ring checksum stat period invalid below 10 ms")
 		}
 		r.config.RingChecksumStatPeriod = period
+		return nil
+	}
+}
+
+// SuspectPeriod configures the period it takes ringpop to declare a node faulty
+// after ringpop has first detected the node to be unresponsive to a healthcheck.
+// When a node is declared faulty it is removed from the consistent hashring and
+// stops forwarding traffic to that node. All keys previously routed to that node
+// will then be routed to the new owner of the key
+func SuspectPeriod(period time.Duration) Option {
+	return func(r *Ringpop) error {
+		r.config.StateTimeouts.Suspect = period
+		return nil
+	}
+}
+
+// FaultyPeriod configures the period Ringpop keeps a faulty node in its memberlist.
+// Even though the node will not receive any traffic it is still present in the
+// list in case it will come back online later. After this timeout ringpop will
+// remove the node from its membership list permanently. If a node happens to come
+// back after it has been removed from the membership Ringpop still allows it to
+// join and take its old position in the hashring. To remove the node from the
+// distributed membership it will mark it as a tombstone which can be removed from
+// every members membership list independently.
+func FaultyPeriod(period time.Duration) Option {
+	return func(r *Ringpop) error {
+		r.config.StateTimeouts.Faulty = period
+		return nil
+	}
+}
+
+// TombstonePeriod configures the period of the last time of the lifecycle in of
+// a node in the membership list. This period should give the gossip protocol the
+// time it needs to disseminate this change. If configured too short the node in
+// question might show up again in faulty state in the distributed memberlist of
+// Ringpop.
+func TombstonePeriod(period time.Duration) Option {
+	return func(r *Ringpop) error {
+		r.config.StateTimeouts.Tombstone = period
 		return nil
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -225,6 +225,53 @@ func (s *RingpopOptionsTestSuite) TestTooSmallRingChecksumStatPeriod() {
 	s.Error(err)
 }
 
+func (s *RingpopOptionsTestSuite) TestSuspectPeriodConfig() {
+	rp, err := New("test", Channel(s.channel), SuspectPeriod(1*time.Second))
+	s.Require().NoError(err)
+	s.Require().NotNil(rp)
+
+	s.Equal(rp.config.StateTimeouts.Suspect, 1*time.Second)
+	s.Equal(rp.config.StateTimeouts.Faulty, time.Duration(0))
+	s.Equal(rp.config.StateTimeouts.Tombstone, time.Duration(0))
+}
+
+func (s *RingpopOptionsTestSuite) TestFaultyPeriodConfig() {
+	rp, err := New("test", Channel(s.channel), FaultyPeriod(2*time.Second))
+	s.Require().NoError(err)
+	s.Require().NotNil(rp)
+
+	s.Equal(rp.config.StateTimeouts.Suspect, time.Duration(0))
+	s.Equal(rp.config.StateTimeouts.Faulty, 2*time.Second)
+	s.Equal(rp.config.StateTimeouts.Tombstone, time.Duration(0))
+}
+
+func (s *RingpopOptionsTestSuite) TestTombstonePeriodConfig() {
+	rp, err := New("test", Channel(s.channel), TombstonePeriod(3*time.Second))
+	s.Require().NoError(err)
+	s.Require().NotNil(rp)
+
+	s.Equal(rp.config.StateTimeouts.Suspect, time.Duration(0))
+	s.Equal(rp.config.StateTimeouts.Faulty, time.Duration(0))
+	s.Equal(rp.config.StateTimeouts.Tombstone, 3*time.Second)
+}
+
+func (s *RingpopOptionsTestSuite) TestCombinedPeriodConfig() {
+	rp, err := New(
+		"test",
+		Channel(s.channel),
+		SuspectPeriod(1*time.Second),
+		FaultyPeriod(2*time.Second),
+		TombstonePeriod(3*time.Second),
+	)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(rp)
+
+	s.Equal(rp.config.StateTimeouts.Suspect, 1*time.Second)
+	s.Equal(rp.config.StateTimeouts.Faulty, 2*time.Second)
+	s.Equal(rp.config.StateTimeouts.Tombstone, 3*time.Second)
+}
+
 func TestRingpopOptionsTestSuite(t *testing.T) {
 	suite.Run(t, new(RingpopOptionsTestSuite))
 }

--- a/ringpop.go
+++ b/ringpop.go
@@ -164,7 +164,8 @@ func (rp *Ringpop) init() error {
 	rp.registerHandlers()
 
 	rp.node = swim.NewNode(rp.config.App, address, rp.subChannel, &swim.Options{
-		Clock: rp.clock,
+		StateTimeouts: rp.config.StateTimeouts,
+		Clock:         rp.clock,
 	})
 	rp.node.RegisterListener(rp)
 

--- a/scripts/testpop/testpop.go
+++ b/scripts/testpop/testpop.go
@@ -23,6 +23,7 @@ package main
 import (
 	"flag"
 	"regexp"
+	"time"
 
 	"github.com/uber-common/bark"
 	"github.com/uber/ringpop-go"
@@ -60,6 +61,9 @@ func main() {
 		ringpop.Channel(ch),
 		ringpop.Identity(*hostport),
 		ringpop.Logger(bark.NewLoggerFromLogrus(logger)),
+		ringpop.SuspectPeriod(5*time.Second),
+		ringpop.FaultyPeriod(5*time.Second),
+		ringpop.TombstonePeriod(5*time.Second),
 	)
 
 	if err := ch.ListenAndServe(*hostport); err != nil {

--- a/swim/member.go
+++ b/swim/member.go
@@ -39,6 +39,9 @@ const (
 
 	// Leave is the member "leave" state
 	Leave = "leave"
+
+	// Tombstone is the member "tombstone" state
+	Tombstone = "tombstone"
 )
 
 // A Member is a member in the member list
@@ -94,7 +97,7 @@ func (m *Member) localOverride(local string, change Change) bool {
 	if m.Address != local {
 		return false
 	}
-	return change.Status == Faulty || change.Status == Suspect
+	return change.Status == Faulty || change.Status == Suspect || change.Status == Tombstone
 }
 
 func statePrecedence(s string) int {
@@ -107,6 +110,8 @@ func statePrecedence(s string) int {
 		return 2
 	case Leave:
 		return 3
+	case Tombstone:
+		return 4
 	default:
 		panic("invalid state")
 	}

--- a/swim/state_transitions_test.go
+++ b/swim/state_transitions_test.go
@@ -24,12 +24,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/ringpop-go/util"
 )
 
 type StateTransitionsSuite struct {
 	suite.Suite
+	clock            *clock.Mock
 	node             *Node
 	stateTransitions *stateTransitions
 	m                *memberlist
@@ -40,10 +42,14 @@ type StateTransitionsSuite struct {
 
 func (s *StateTransitionsSuite) SetupTest() {
 	s.incarnation = util.TimeNowMS()
+	s.clock = clock.NewMock()
 	s.node = NewNode("test", "127.0.0.1:3001", nil, &Options{
 		StateTimeouts: StateTimeouts{
-			Suspect: 1000 * time.Second,
+			// if we use 24 hours the faulty to tombstone test takes 20 seconds
+			// because it executes a day worth of timers
+			Faulty: 10 * time.Second,
 		},
+		Clock: s.clock,
 	})
 	s.stateTransitions = s.node.stateTransitions
 	s.m = s.node.memberlist
@@ -102,17 +108,42 @@ func (s *StateTransitionsSuite) TestSuspectDisabled() {
 }
 
 func (s *StateTransitionsSuite) TestSuspectBecomesFaulty() {
-	s.stateTransitions.timeouts.Suspect = time.Millisecond
-
-	s.m.MakeAlive(s.suspect.Address, s.suspect.Incarnation)
+	s.m.MakeSuspect(s.suspect.Address, s.suspect.Incarnation)
 	member, _ := s.m.Member(s.suspect.Address)
 	s.Require().NotNil(member, "expected cannot be nil")
 
 	s.stateTransitions.ScheduleSuspectToFaulty(*member)
-	s.NotNil(s.stateTransitions.timer(member.Address), "expected suspicion timer to be set")
+	s.NotNil(s.stateTransitions.timer(member.Address), "expected state transtition timer to be set")
 
-	time.Sleep(5 * time.Millisecond)
+	s.clock.Add(5*time.Second + 1)
 	s.Equal(Faulty, member.Status, "expected member to be faulty")
+}
+
+func (s *StateTransitionsSuite) TestFaultyBecomesTombstone() {
+	s.m.MakeFaulty(s.suspect.Address, s.suspect.Incarnation)
+	member, _ := s.m.Member(s.suspect.Address)
+	s.Require().NotNil(member, "expected cannot be nil")
+
+	s.stateTransitions.ScheduleFaultyToTombstone(*member)
+	s.NotNil(s.stateTransitions.timer(member.Address), "expected state transtition timer to be set")
+
+	s.clock.Add(10 * time.Second)
+	s.Equal(Tombstone, member.Status, "expected member to be tombstone")
+}
+
+func (s *StateTransitionsSuite) TestTombstoneBecomesEvicted() {
+	// we need to first make the suspect alive, otherwise we can't make it a tombstome
+	s.m.MakeAlive(s.suspect.Address, s.suspect.Incarnation)
+	s.m.MakeTombstone(s.suspect.Address, s.suspect.Incarnation)
+	member, _ := s.m.Member(s.suspect.Address)
+	s.Require().NotNil(member, "expected cannot be nil")
+
+	s.stateTransitions.ScheduleTombstoneToEvict(*member)
+	s.NotNil(s.stateTransitions.timer(member.Address), "expected state transtition timer to be set")
+
+	s.clock.Add(1 * time.Minute)
+	_, found := s.m.Member(s.suspect.Address)
+	s.False(found, "expected member to be removed from memberlist")
 }
 
 // TestTimerCreated tests that starting suspicion for a node creates a
@@ -130,6 +161,24 @@ func (s *StateTransitionsSuite) TestTimerCreated() {
 	s.stateTransitions.ScheduleSuspectToFaulty(*member)
 
 	s.NotEqual(old, s.stateTransitions.timer(member.Address), "expected timer to change")
+}
+
+// TestTimerCreated tests that starting suspicion for a node creates a
+// countdown timer that is responsible for marking a node as faulty at the end
+// of the timeout.
+func (s *StateTransitionsSuite) TestTimerCanceled() {
+	s.m.MakeAlive(s.suspect.Address, s.suspect.Incarnation)
+	member, _ := s.m.Member(s.suspect.Address)
+
+	old := s.stateTransitions.timer(member.Address)
+	s.Require().Nil(old, "expected timer to be nil")
+
+	// Start suspcision, which should create a timer
+	s.stateTransitions.ScheduleSuspectToFaulty(*member)
+	s.NotEqual(old, s.stateTransitions.timer(member.Address), "expected timer to change")
+
+	s.stateTransitions.Cancel(*member)
+	s.Require().Nil(s.stateTransitions.timer(member.Address), "expected timer to have been canceled")
 }
 
 func (s *StateTransitionsSuite) TestSuspicionDisableStopsTimers() {

--- a/test/run-integration-tests
+++ b/test/run-integration-tests
@@ -6,6 +6,7 @@ set -eo pipefail
 
 declare project_root="${0%/*}/.."
 declare ringpop_common_dir="${0%/*}/ringpop-common"
+declare ringpop_common_branch="master"
 declare tap_filter="${ringpop_common_dir}/test/tap-filter"
 
 declare test_cluster_sizes="1 2 3 4 5 10"
@@ -60,12 +61,14 @@ prefix() {
 #
 fetch-ringpop-common() {
     if [ ! -e "$ringpop_common_dir" ]; then
-        run git clone --depth=1 https://github.com/uber/ringpop-common.git "$ringpop_common_dir"
+        run git clone --depth=1 https://github.com/uber/ringpop-common.git "$ringpop_common_dir" --branch "$ringpop_common_branch"
     fi
 
     run cd "$ringpop_common_dir"
-    #run git checkout master
-    run git pull
+    #run git checkout latest version of $ringpop_common_branch
+    run git fetch origin "$ringpop_common_branch"
+    run git checkout "FETCH_HEAD"
+
     run cd - >/dev/null
 
     run cd "${ringpop_common_dir}/test"
@@ -102,7 +105,7 @@ run-test-for-cluster-size() {
     # if the test fails. This avoids interleaving of output to the terminal
     # when tests are running in parallel.
     node "${ringpop_common_dir}/test/it-tests.js" \
-        -s "[$1]" "${project_root}/testpop" &>$output_file || err=$?
+        -s "[$1]" --enable-feature "reaping-faulty-nodes" "${project_root}/testpop" &>$output_file || err=$?
 
     if [ $PIPESTATUS -gt 0 ]; then
         echo "ERROR: Test errored for cluster size $cluster_size" | \


### PR DESCRIPTION
This branch is an implementation of reaping faulty nodes.

The basic design is:

1. Add extra status for a node that is called `tombstone`
2. A member that has the `tombstone` state will not be added to the checksum of the membership. The membership list with the tombstone has the same checksum as the membership list without the member. This makes it possible to remove the `tombstone` member from the membership list later on without the possibility for full sync mechanism of ringpop to make the deleted member appear again.
3. If a node joins a cluster where a tombstone is in the member list, or when a node receives an update of a `tombstone` for an unknown member it will be ignored.

These 3 rules together make it possible to 'forget' about a faulty node in a distributed system.