### PR TITLE
Add event that is fired after bootstrapping.

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -31,6 +31,9 @@ type EventListener interface {
 	HandleEvent(event Event)
 }
 
+// A Bootstrapped event is sent when ringpop has bootstrapped
+type Bootstrapped struct{}
+
 // A RingChangedEvent is sent when servers are added and/or removed from the ring
 type RingChangedEvent struct {
 	ServersAdded   []string

--- a/ringpop.go
+++ b/ringpop.go
@@ -366,6 +366,9 @@ func (rp *Ringpop) Bootstrap(userBootstrapOpts *swim.BootstrapOptions) ([]string
 	rp.setState(ready)
 
 	rp.logger.WithField("joined", joined).Info("bootstrap complete")
+
+	rp.emit(events.Bootstrapped{})
+
 	return joined, nil
 }
 

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/ringpop-go/events"
+	eventsmock "github.com/uber/ringpop-go/events/test/mocks"
 	"github.com/uber/ringpop-go/forward"
 	"github.com/uber/ringpop-go/swim"
 	"github.com/uber/ringpop-go/test/mocks"
@@ -385,6 +386,37 @@ func (s *RingpopTestSuite) TestStateReady() {
 	createSingleNodeCluster(s.ringpop)
 
 	s.Equal(ready, s.ringpop.state)
+}
+
+// TestStateReady tests that Ringpop is ready after successful bootstrapping.
+func (s *RingpopTestSuite) TestBootstrappedEvent() {
+	called := make(chan bool, 1)
+
+	l := &eventsmock.EventListener{}
+
+	// trap Bootstrapped event and signal on the channel that we received the call
+	l.On("HandleEvent", events.Bootstrapped{}).Return().Run(func(args mock.Arguments) {
+		called <- true
+	})
+
+	// There are more events being fired which we don't care about
+	l.On("HandleEvent", mock.Anything).Return()
+
+	s.ringpop.RegisterListener(l)
+
+	// Bootstrap
+	createSingleNodeCluster(s.ringpop)
+
+	// block till we have received the bootstrapped event with a timeout of 100ms in the case that it failes to fire
+	select {
+	case <-called:
+		break
+	case <-time.After(100 * time.Millisecond):
+		s.Fail("no bootstrap event after bootstrapping")
+	}
+
+	// Assert that the Bootstrapped event has fired
+	l.AssertCalled(s.T(), "HandleEvent", events.Bootstrapped{})
 }
 
 // TestStateDestroyed tests that Ringpop is in a destroyed state after calling


### PR DESCRIPTION
This adds an event that fires after the bootstrapping has completed.

It can be used for applications to initialize extra systems that rely on `Lookup` and `WhoAmI` to work.