### PR TITLE
Ws refactor calls disco provider wait for convergence

### DIFF
--- a/ringpop.go
+++ b/ringpop.go
@@ -543,11 +543,7 @@ func (rp *Ringpop) handleChanges(changes []swim.Change) {
 		}
 	}
 
-	start := time.Now()
 	rp.ring.AddRemoveServers(serversToAdd, serversToRemove)
-	treeConstructionTime := time.Now().Sub(start)
-	rp.statter.RecordTimer(rp.getStatKey("tree"), nil, treeConstructionTime)
-
 }
 
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =

--- a/ringpop.go
+++ b/ringpop.go
@@ -543,7 +543,11 @@ func (rp *Ringpop) handleChanges(changes []swim.Change) {
 		}
 	}
 
+	start := time.Now()
 	rp.ring.AddRemoveServers(serversToAdd, serversToRemove)
+	treeConstructionTime := time.Now().Sub(start)
+	rp.statter.RecordTimer(rp.getStatKey("tree"), nil, treeConstructionTime)
+
 }
 
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =

--- a/ringpop.go
+++ b/ringpop.go
@@ -426,6 +426,9 @@ func (rp *Ringpop) HandleEvent(event events.Event) {
 		rp.statter.IncCounter(rp.getStatKey("join.succeeded"), nil, 1)
 		rp.statter.RecordTimer(rp.getStatKey("join"), nil, event.Duration)
 
+	case swim.AddJoinListEvent:
+		rp.statter.RecordTimer(rp.getStatKey("join.add-join-list"), nil, event.Duration)
+
 	case swim.PingSendEvent:
 		rp.statter.IncCounter(rp.getStatKey("ping.send"), nil, 1)
 

--- a/swim/events.go
+++ b/swim/events.go
@@ -84,6 +84,11 @@ type JoinCompleteEvent struct {
 	Joined    []string      `json:"joined"`
 }
 
+// AddJoinListEvent is sent when a join list is added to the membership
+type AddJoinListEvent struct {
+	Duration time.Duration `json:"duration"`
+}
+
 // JoinFailedReason indicates the reason a join failed
 type JoinFailedReason string
 

--- a/swim/join_sender.go
+++ b/swim/join_sender.go
@@ -410,8 +410,9 @@ func (j *joinSender) JoinGroup(nodesJoined []string) ([]string, []string) {
 			start := time.Now()
 			j.node.memberlist.AddJoinList(res.Membership)
 
-			addJoinListTime := time.Now().Sub(start)
-			rp.statter.RecordTimer(rp.getStatKey("join.add-join-list"), nil, addJoinListTime)
+			j.node.emit(AddJoinListEvent{
+				Duration: time.Now().Sub(start),
+			})
 		}(target)
 	}
 

--- a/swim/join_sender.go
+++ b/swim/join_sender.go
@@ -27,8 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/uber/ringpop-go/discovery"
-
 	log "github.com/uber-common/bark"
 	"github.com/uber/ringpop-go/logging"
 	"github.com/uber/ringpop-go/shared"
@@ -68,10 +66,6 @@ type joinOpts struct {
 	size              int
 	maxJoinDuration   time.Duration
 	parallelismFactor int
-
-	// discoverProvider is the DiscoverProvider that this joinSender will use to
-	// enumerate bootstrap hosts.
-	discoverProvider discovery.DiscoverProvider
 
 	// delayer delays repeated join attempts.
 	delayer joinDelayer
@@ -123,13 +117,13 @@ func newJoinSender(node *Node, opts *joinOpts) (*joinSender, error) {
 		opts = &joinOpts{}
 	}
 
-	if opts.discoverProvider == nil {
+	if node.discoverProvider == nil {
 		return nil, errors.New("no discover provider")
 	}
 
 	// Resolve/retrieve bootstrap hosts from the provider specified in the
 	// join options.
-	bootstrapHosts, err := opts.discoverProvider.Hosts()
+	bootstrapHosts, err := node.discoverProvider.Hosts()
 	if err != nil {
 		return nil, err
 	}

--- a/swim/join_test.go
+++ b/swim/join_test.go
@@ -52,9 +52,9 @@ func (s *JoinSenderTestSuite) TestSelectGroup() {
 	fakeHosts := fakeHostPorts(1, 1, 2, 3)
 	bootstrapHosts := append(fakeHosts, s.node.Address())
 
-	joiner, err := newJoinSender(s.node, &joinOpts{
-		discoverProvider: statichosts.New(bootstrapHosts...),
-	})
+	s.node.discoverProvider = statichosts.New(bootstrapHosts...)
+	joiner, err := newJoinSender(s.node, nil)
+
 	s.Require().NoError(err, "cannot have an error")
 	s.Require().NotNil(joiner, "joiner cannot be nil")
 
@@ -68,9 +68,9 @@ func (s *JoinSenderTestSuite) TestSelectMultipleGroups() {
 	bootstrapHosts := append(fakeHostPorts(1, 1, 2, 3), s.node.Address())
 	expected := fakeHostPorts(1, 1, 2, 3)
 
-	joiner, err := newJoinSender(s.node, &joinOpts{
-		discoverProvider: statichosts.New(bootstrapHosts...),
-	})
+	s.node.discoverProvider = statichosts.New(bootstrapHosts...)
+	joiner, err := newJoinSender(s.node, nil)
+
 	s.Require().NoError(err, "cannot have an error")
 	s.Require().NotNil(joiner, "joiner cannot be nil")
 
@@ -87,9 +87,9 @@ func (s *JoinSenderTestSuite) TestSelectMultipleGroups() {
 func (s *JoinSenderTestSuite) TestSelectGroupExcludes() {
 	bootstrapHosts := fakeHostPorts(1, 1, 1, 5)
 
-	joiner, err := newJoinSender(s.node, &joinOpts{
-		discoverProvider: statichosts.New(bootstrapHosts...),
-	})
+	s.node.discoverProvider = statichosts.New(bootstrapHosts...)
+	joiner, err := newJoinSender(s.node, nil)
+
 	s.Require().NoError(err, "cannot have an error")
 	s.Require().NotNil(joiner, "joiner cannot be nil")
 
@@ -104,8 +104,8 @@ func (s *JoinSenderTestSuite) TestSelectGroupExcludes() {
 func (s *JoinSenderTestSuite) TestSelectGroupPrioritizes() {
 	bootstrapHosts := append(fakeHostPorts(1, 4, 1, 1), fakeHostPorts(1, 1, 2, 4)...)
 
+	s.node.discoverProvider = statichosts.New(bootstrapHosts...)
 	joiner, err := newJoinSender(s.node, &joinOpts{
-		discoverProvider:  statichosts.New(bootstrapHosts...),
 		parallelismFactor: 1,
 	})
 	s.Require().NoError(err, "cannot have an error")
@@ -120,8 +120,8 @@ func (s *JoinSenderTestSuite) TestSelectGroupPrioritizes() {
 func (s *JoinSenderTestSuite) TestSelectGroupMixes() {
 	bootstrapHosts := append(fakeHostPorts(1, 2, 1, 1), fakeHostPorts(1, 1, 2, 3)...)
 
+	s.node.discoverProvider = statichosts.New(bootstrapHosts...)
 	joiner, err := newJoinSender(s.node, &joinOpts{
-		discoverProvider:  statichosts.New(bootstrapHosts...),
 		parallelismFactor: 1,
 	})
 	s.Require().NoError(err, "cannot have an error")
@@ -141,9 +141,9 @@ func (s *JoinSenderTestSuite) TestJoinDifferentApp() {
 	bootstrapNodes(s.T(), s.tnode)
 	bootstrapNodes(s.T(), peer)
 
-	joiner, err := newJoinSender(s.node, &joinOpts{
-		discoverProvider: statichosts.New(fakeHostPorts(1, 1, 1, 1)...),
-	})
+	s.node.discoverProvider = statichosts.New(fakeHostPorts(1, 1, 1, 1)...)
+	joiner, err := newJoinSender(s.node, nil)
+
 	s.Require().NoError(err, "cannot have an error")
 	s.Require().NotNil(joiner, "joiner cannot be nil")
 
@@ -161,15 +161,15 @@ func (s *JoinSenderTestSuite) TestJoinDifferentApp() {
 
 func (s *JoinSenderTestSuite) TestJoinSelf() {
 	// Set up a real listening channel
+	s.tnode.Destroy()
 	s.tnode = newChannelNode(s.T())
 	s.node = s.tnode.node
-	defer s.tnode.Destroy()
 
 	bootstrapNodes(s.T(), s.tnode)
 
-	joiner, err := newJoinSender(s.node, &joinOpts{
-		discoverProvider: statichosts.New(fakeHostPorts(1, 1, 1, 1)...),
-	})
+	s.node.discoverProvider = statichosts.New(fakeHostPorts(1, 1, 1, 1)...)
+	joiner, err := newJoinSender(s.node, nil)
+
 	s.Require().NoError(err, "cannot have an error")
 	s.Require().NotNil(joiner, "joiner cannot be nil")
 
@@ -187,10 +187,12 @@ func (s *JoinSenderTestSuite) TestJoinSelf() {
 
 func (s *JoinSenderTestSuite) TestCustomDelayer() {
 	delayer := &nullDelayer{}
+
+	s.node.discoverProvider = statichosts.New(fakeHostPorts(1, 1, 1, 1)...)
 	joiner, err := newJoinSender(s.node, &joinOpts{
-		delayer:          delayer,
-		discoverProvider: statichosts.New(fakeHostPorts(1, 1, 1, 1)...),
+		delayer: delayer,
 	})
+
 	s.NoError(err, "expected valid joiner")
 	s.Equal(delayer, joiner.delayer, "custom delayer was set")
 }

--- a/swim/join_test.go
+++ b/swim/join_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/ringpop-go/discovery/statichosts"
-	"github.com/uber/tchannel-go/json"
 )
 
 type JoinSenderTestSuite struct {
@@ -147,16 +146,9 @@ func (s *JoinSenderTestSuite) TestJoinDifferentApp() {
 	s.Require().NoError(err, "cannot have an error")
 	s.Require().NotNil(joiner, "joiner cannot be nil")
 
-	ctx, cancel := json.NewContext(joiner.timeout)
-	defer cancel()
-
-	var res joinResponse
-	select {
-	case err := <-joiner.MakeCall(ctx, peer.node.Address(), &res):
-		s.Error(err, "expected join to fail for different apps")
-	case <-ctx.Done():
-		s.Fail("expected join to not timeout")
-	}
+	res, err := sendJoinRequest(s.node, peer.node.Address(), joiner.timeout)
+	s.Nil(res, "expected err, not a response")
+	s.Error(err, "expected join to fail for different apps")
 }
 
 func (s *JoinSenderTestSuite) TestJoinSelf() {
@@ -173,16 +165,9 @@ func (s *JoinSenderTestSuite) TestJoinSelf() {
 	s.Require().NoError(err, "cannot have an error")
 	s.Require().NotNil(joiner, "joiner cannot be nil")
 
-	ctx, cancel := json.NewContext(joiner.timeout)
-	defer cancel()
-
-	var res joinResponse
-	select {
-	case err := <-joiner.MakeCall(ctx, s.node.Address(), &res):
-		s.Error(err, "expected join to fail for different apps")
-	case <-ctx.Done():
-		s.Fail("expected join to not timeout")
-	}
+	res, err := sendJoinRequest(s.node, s.node.Address(), joiner.timeout)
+	s.Nil(res, "expected err, not a response")
+	s.Error(err, "expected join to fail when joining yourself")
 }
 
 func (s *JoinSenderTestSuite) TestCustomDelayer() {

--- a/swim/node.go
+++ b/swim/node.go
@@ -136,6 +136,7 @@ type Node struct {
 	}
 
 	channel          shared.SubChannel
+	discoverProvider discovery.DiscoverProvider
 	memberlist       *memberlist
 	memberiter       memberIter
 	disseminator     *disseminator
@@ -343,12 +344,12 @@ func (n *Node) Bootstrap(opts *BootstrapOptions) ([]string, error) {
 
 	n.memberlist.Reincarnate()
 
+	n.discoverProvider = opts.DiscoverProvider
 	joinOpts := &joinOpts{
 		timeout:           opts.JoinTimeout,
 		size:              opts.JoinSize,
 		maxJoinDuration:   opts.MaxJoinDuration,
 		parallelismFactor: opts.ParallelismFactor,
-		discoverProvider:  opts.DiscoverProvider,
 	}
 
 	joined, err := sendJoin(n, joinOpts)

--- a/swim/ping_sender.go
+++ b/swim/ping_sender.go
@@ -39,108 +39,25 @@ type ping struct {
 	SourceIncarnation int64    `json:"sourceIncarnationNumber"`
 }
 
-// A PingSender is used to send a SWIM gossip ping over TChannel to target node
-type pingSender struct {
-	node    *Node
-	target  string
-	timeout time.Duration
-	logger  log.Logger
-}
+// sendPing sends a ping to target node that times out after timeout
+func sendPing(node *Node, target string, timeout time.Duration) (*ping, error) {
+	changes, bumpPiggybackCounters := node.disseminator.IssueAsSender()
 
-// NewPingSender returns a new PingSender that can be used to send a ping to target node
-func newPingSender(node *Node, target string, timeout time.Duration) *pingSender {
-	ps := &pingSender{
-		node:    node,
-		target:  target,
-		timeout: timeout,
-		logger:  logging.Logger("ping").WithField("local", node.Address()),
+	res, err := sendPingWithChanges(node, target, changes, timeout)
+	if err != nil {
+		return res, err
 	}
 
-	return ps
-}
+	// when ping was successful
+	bumpPiggybackCounters()
 
-func (p *pingSender) SendPing() (*ping, error) {
-	ctx, cancel := shared.NewTChannelContext(p.timeout)
-
-	defer cancel()
-
-	var res ping
-	select {
-	case err := <-p.MakeCall(ctx, &res):
-		if err != nil {
-			return nil, err
-		}
-		return &res, nil
-
-	case <-ctx.Done(): // ping timed out
-		return nil, errors.New("ping timed out")
-	}
-}
-
-func (p *pingSender) MakeCall(ctx json.Context, res *ping) <-chan error {
-	errC := make(chan error)
-
-	go func() {
-		defer close(errC)
-
-		peer := p.node.channel.Peers().GetOrAdd(p.target)
-
-		changes, bumpPiggybackCounters := p.node.disseminator.IssueAsSender()
-		req := ping{
-			Checksum:          p.node.memberlist.Checksum(),
-			Changes:           changes,
-			Source:            p.node.Address(),
-			SourceIncarnation: p.node.Incarnation(),
-		}
-
-		p.node.emit(PingSendEvent{
-			Local:   p.node.Address(),
-			Remote:  p.target,
-			Changes: req.Changes,
-		})
-
-		p.logger.WithFields(log.Fields{
-			"remote":  p.target,
-			"changes": req.Changes,
-		}).Debug("ping send")
-
-		var startTime = time.Now()
-
-		err := json.CallPeer(ctx, peer, p.node.service, "/protocol/ping", req, res)
-		if err != nil {
-			p.logger.WithFields(log.Fields{
-				"remote": p.target,
-				"error":  err,
-			}).Debug("ping failed")
-			errC <- err
-			return
-		}
-
-		// when ping was successful
-		bumpPiggybackCounters()
-
-		p.node.emit(PingSendCompleteEvent{
-			Local:    p.node.Address(),
-			Remote:   p.target,
-			Changes:  req.Changes,
-			Duration: time.Now().Sub(startTime),
-		})
-
-		errC <- nil
-	}()
-
-	return errC
+	return res, err
 }
 
 // sendPingWithChanges sends a special ping to the target with the given changes.
 // In normal pings the disseminator is consulted to create issue the changes,
 // this is not the case in this function. Only the given changes are transmitted.
 func sendPingWithChanges(node *Node, target string, changes []Change, timeout time.Duration) (*ping, error) {
-	ctx, cancel := shared.NewTChannelContext(timeout)
-	defer cancel()
-
-	peer := node.channel.Peers().GetOrAdd(target)
-
 	req := ping{
 		Checksum:          node.memberlist.Checksum(),
 		Changes:           changes,
@@ -148,22 +65,56 @@ func sendPingWithChanges(node *Node, target string, changes []Change, timeout ti
 		SourceIncarnation: node.Incarnation(),
 	}
 
-	res := &ping{}
+	node.emit(PingSendEvent{
+		Local:   node.Address(),
+		Remote:  target,
+		Changes: req.Changes,
+	})
 
-	node.logger.WithFields(log.Fields{
+	logging.Logger("ping").WithFields(log.Fields{
+		"local":   node.Address(),
 		"remote":  target,
-		"changes": changes,
-	}).Debug("ping send with custom changes")
+		"changes": req.Changes,
+	}).Debug("ping send")
 
-	// var startTime = time.Now()
+	ctx, cancel := shared.NewTChannelContext(timeout)
+	defer cancel()
 
-	err := json.CallPeer(ctx, peer, node.service, "/protocol/ping", req, res)
-	return res, err
-}
+	peer := node.channel.Peers().GetOrAdd(target)
+	startTime := time.Now()
 
-// SendPing sends a ping to target node that times out after timeout
-func sendPing(node *Node, target string, timeout time.Duration) (*ping, error) {
-	ps := newPingSender(node, target, timeout)
-	res, err := ps.SendPing()
+	// send the ping
+	errC := make(chan error)
+	res := &ping{}
+	go func() {
+		errC <- json.CallPeer(ctx, peer, node.service, "/protocol/ping", req, res)
+	}()
+
+	// get result or timeout
+	var err error
+	select {
+	case err = <-errC:
+	case <-ctx.Done():
+		err = errors.New("ping timed out")
+	}
+
+	if err != nil {
+		// ping failed
+		logging.Logger("ping").WithFields(log.Fields{
+			"local":  node.Address(),
+			"remote": target,
+			"error":  err,
+		}).Debug("ping failed")
+
+		return nil, err
+	}
+
+	node.emit(PingSendCompleteEvent{
+		Local:    node.Address(),
+		Remote:   target,
+		Changes:  req.Changes,
+		Duration: time.Now().Sub(startTime),
+	})
+
 	return res, err
 }


### PR DESCRIPTION
Some refactoring, mostly to make it easier to make calls. This is useful for the implementation of bidirectional full syncs and partition healing which will follow after this has landed.

1. remove unnecessary concurrency in waitForConvergence
2. add stats for tree construction time
3. make discover provider part of the node and no longer part of the join sender
4. add sendPingWithChanges and sendJoinRequest method
5. refactor MakeCall to easier to understand sendJoinRequest/sendPing
 (also adds timeout via ctx.Done to sendPingWithChanges)