### PR TITLE
Ws bidirectional full sync

### DIFF
--- a/ringpop.go
+++ b/ringpop.go
@@ -415,6 +415,15 @@ func (rp *Ringpop) HandleEvent(event events.Event) {
 	case swim.FullSyncEvent:
 		rp.statter.IncCounter(rp.getStatKey("full-sync"), nil, 1)
 
+	case swim.StartReverseFullSyncEvent:
+		rp.statter.IncCounter(rp.getStatKey("full-sync.reverse"), nil, 1)
+
+	case swim.OmitReverseFullSyncEvent:
+		rp.statter.IncCounter(rp.getStatKey("full-sync.reverse-omitted"), nil, 1)
+
+	case swim.RedundantReverseFullSyncEvent:
+		rp.statter.IncCounter(rp.getStatKey("full-sync.redundant-reverse"), nil, 1)
+
 	case swim.MaxPAdjustedEvent:
 		rp.statter.UpdateGauge(rp.getStatKey("max-piggyback"), nil, int64(event.NewPCount))
 

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -204,6 +204,18 @@ func (s *RingpopTestSuite) TestHandleEvents() {
 	s.Equal(int64(0 /* events are faked, ringpop still has 0 members */), stats.vals["ringpop.127_0_0_1_3001.num-members"], "missing num-members stats for member being set to unknown")
 	// expected listener to record 3 events (forwarded swim event, checksum event, and ring changed event)
 
+	s.ringpop.HandleEvent(swim.FullSyncEvent{})
+	s.Equal(int64(1), stats.vals["ringpop.127_0_0_1_3001.full-sync"], "missing stats for full sync")
+
+	s.ringpop.HandleEvent(swim.StartReverseFullSyncEvent{})
+	s.Equal(int64(1), stats.vals["ringpop.127_0_0_1_3001.full-sync.reverse"], "missing stats for reverse full sync")
+
+	s.ringpop.HandleEvent(swim.OmitReverseFullSyncEvent{})
+	s.Equal(int64(1), stats.vals["ringpop.127_0_0_1_3001.full-sync.reverse-omitted"], "missing stats for omitted reverse full sync")
+
+	s.ringpop.HandleEvent(swim.RedundantReverseFullSyncEvent{})
+	s.Equal(int64(1), stats.vals["ringpop.127_0_0_1_3001.full-sync.redundant-reverse"], "missing stats for redundant reverse full sync")
+
 	s.ringpop.HandleEvent(swim.MaxPAdjustedEvent{NewPCount: 100})
 	s.Equal(int64(100), stats.vals["ringpop.127_0_0_1_3001.max-piggyback"], "missing stats for piggyback adjustment")
 	// expected listener to record 1 event
@@ -372,7 +384,7 @@ func (s *RingpopTestSuite) TestHandleEvents() {
 	// expected listener to record 1 event
 
 	time.Sleep(time.Millisecond) // sleep for a bit so that events can be recorded
-	s.Equal(42, listener.EventCount(), "incorrect count for emitted events")
+	s.Equal(46, listener.EventCount(), "incorrect count for emitted events")
 }
 
 func (s *RingpopTestSuite) TestRingpopReady() {

--- a/swim/disseminator.go
+++ b/swim/disseminator.go
@@ -23,6 +23,7 @@ package swim
 import (
 	"math"
 	"sync"
+	"time"
 
 	log "github.com/uber-common/bark"
 	"github.com/uber/ringpop-go/logging"
@@ -53,16 +54,19 @@ type disseminator struct {
 	sync.RWMutex
 
 	logger log.Logger
+
+	reverseFullSyncJobs chan struct{}
 }
 
 // newDisseminator returns a new Disseminator instance.
 func newDisseminator(n *Node) *disseminator {
 	d := &disseminator{
-		node:    n,
-		changes: make(map[string]*pChange),
-		maxP:    defaultPFactor,
-		pFactor: defaultPFactor,
-		logger:  logging.Logger("disseminator").WithField("local", n.Address()),
+		node:                n,
+		changes:             make(map[string]*pChange),
+		maxP:                defaultPFactor,
+		pFactor:             defaultPFactor,
+		logger:              logging.Logger("disseminator").WithField("local", n.Address()),
+		reverseFullSyncJobs: make(chan struct{}, n.maxReverseFullSyncJobs),
 	}
 
 	return d
@@ -244,4 +248,57 @@ func (d *disseminator) ChangesCount() int {
 	c := len(d.changes)
 	d.RUnlock()
 	return c
+}
+
+// tryStartReverseFullSync fires a goroutine that performs a full sync. We omit
+// the reverse full sync if the maximum number of processes are already
+// running. This ensures no more than reverseFullSyncJobs processes are
+// running concurrently.
+func (d *disseminator) tryStartReverseFullSync(target string, timeout time.Duration) {
+	// occupy a job, return if none are available
+	select {
+	case d.reverseFullSyncJobs <- struct{}{}:
+		// continue if job is available
+	default:
+		d.logger.WithFields(log.Fields{
+			"remote": target,
+		}).Info("omit bidirectional full sync, too many already running")
+
+		d.node.emit(OmitReverseFullSyncEvent{Target: target})
+		return
+	}
+
+	// start reverse full sync
+	go func() {
+		d.reverseFullSync(target, timeout)
+
+		// create a new vacancy when the job is done
+		<-d.reverseFullSyncJobs
+	}()
+}
+
+// reverseFullSync is the second part of a bidirectional full sync. The first
+// part is performed by the IssueAsReceiver method. The reverse full sync
+// ensures that this node merges the membership of the target node's membership
+// with its own.
+func (d *disseminator) reverseFullSync(target string, timeout time.Duration) {
+	d.node.emit(StartReverseFullSyncEvent{Target: target})
+
+	res, err := sendJoinRequest(d.node, target, timeout)
+	if err != nil || res == nil {
+		d.logger.WithFields(log.Fields{
+			"remote": target,
+			"error":  err,
+		}).Warn("bidirectional full sync failed due to failed join request")
+		return
+	}
+
+	d.logger.WithFields(log.Fields{
+		"remote": target,
+	}).Info("bidirectional full sync")
+
+	cs := d.node.memberlist.Update(res.Membership)
+	if len(cs) == 0 {
+		d.node.emit(RedundantReverseFullSyncEvent{Target: target})
+	}
 }

--- a/swim/disseminator_test.go
+++ b/swim/disseminator_test.go
@@ -21,8 +21,11 @@
 package swim
 
 import (
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/ringpop-go/util"
 )
@@ -355,4 +358,160 @@ func contains(cs []Change, address string) bool {
 
 func TestDisseminatorTestSuite(t *testing.T) {
 	suite.Run(t, new(DisseminatorTestSuite))
+}
+
+// TestBidirectionalFullSync creates two nodes a and b. The nodes are set up
+// such that a has b in its memberlist, but b doesn't have a in its memberlist.
+// Next we let a ping b, b issues a full sync but that doesn't help much
+// because a already knows about b. If bidirectional full syncs is implemented
+// b will also become aware of a's memberlist and thus the ring converges
+func TestBidirectionalFullSync(t *testing.T) {
+	// create two nodes: a and b
+	a := newChannelNode(t)
+	defer a.Destroy()
+
+	b := newChannelNode(t)
+	defer b.Destroy()
+
+	// after bootstrap a's memberlist contains a and b,
+	// but b's membership only contains b.
+	bootstrapNodes(t, b, a)
+
+	// clear changes so that a full sync will be issued
+	a.node.disseminator.ClearChanges()
+	b.node.disseminator.ClearChanges()
+
+	// check that indeed b's memberlist doesn't contain a
+	addrA := a.node.Address()
+	_, has := b.node.memberlist.Member(addrA)
+	assert.False(t, has, "expected that a is not yet part of b's membership")
+
+	cont := make(chan struct{})
+
+	// only when a reverse full sync is issued the membership of b changes
+	// we listen for a membership change and continue the main thread of the test
+	b.node.RegisterListener(on(MemberlistChangesAppliedEvent{}, func() {
+		cont <- struct{}{}
+	}))
+
+	// this forces a to ping b, b will respond with a full sync and
+	// perform a reverse full sync subsequently
+	a.node.pingNextMember()
+
+	// wait until the membership has changed and the cont channel is sent a signal
+	select {
+	case <-time.After(time.Second):
+		assert.Fail(t, "Test timed out, memberships did not converge")
+	case <-cont:
+	}
+
+	// check that b has indeed added a to its membership
+	_, has = b.node.memberlist.Member(addrA)
+	assert.True(t, has, "expected that a is part of b's membership now")
+}
+
+// TestThrottleBidirectionalFullSyncs tests if we throttle the maximum number
+// of reverse full syncs running at the same time. In this test, we start
+// maxReverseFullSyncJobs+1 reverse full syncs and we block these routines midway
+// by waiting for the block channel. The last reverse full sync will be omitted
+// because the max number of reverse full syncs is in process (albeit blocked).
+// We wait and listen for the OmitReverseFullSyncEvent. When it fires, we
+// continue the test and count if the number of started reverse full syncs is
+// indeed equal to the maxBidirectionalFullSync variable.
+func TestThrottleBidirectionalFullSyncs(t *testing.T) {
+	tnode := newChannelNode(t)
+	maxJobs := tnode.node.maxReverseFullSyncJobs
+
+	tnodes := genChannelNodes(t, maxJobs+1)
+
+	bootstrapNodes(t, append(tnodes, tnode)...)
+	waitForConvergence(t, time.Second, append(tnodes, tnode)...)
+	block := make(chan struct{})
+	quit := make(chan struct{})
+	total := int64(0)
+
+	// Block the reverse full sync procedure to test if we throttle correctly.
+	tnode.node.RegisterListener(on(StartReverseFullSyncEvent{}, func() {
+		atomic.AddInt64(&total, 1)
+		<-block
+	}))
+
+	// Listen for a reverse full sync that is omitted because the max number of
+	// reverse full sync routines are running.
+	tnode.node.RegisterListener(on(OmitReverseFullSyncEvent{}, func() {
+		go func() {
+			for i := 0; i < maxJobs; i++ {
+				block <- struct{}{}
+			}
+			close(quit)
+		}()
+	}))
+
+	// Start the reverse full syncs.
+	for _, tn := range tnodes {
+		target := tn.node.Address()
+		tnode.node.disseminator.tryStartReverseFullSync(target, time.Second)
+	}
+
+	// The last tryStartReverseFullSync should fail to start a reverse full
+	// sync because the max number of reverse full sync routines are running.
+	// The OmitReverseFullSync event is handled above, when it fires the
+	// handler unblocks all the running reverse full syncs, thereafter it
+	// closes the quit channel so that the test continue and pass.
+	select {
+	case <-quit:
+	case <-time.After(time.Second):
+		assert.Fail(t, "test timed out, onOmitReverseFullSync listener didn't close quit channel")
+	}
+
+	assert.Equal(t, int64(maxJobs), total, "expected a throttled amount of concurrent jobs")
+}
+
+// TestReverseFullSync starts two partitions and checks if reverseFullSync
+// merges them.
+func TestReverseFullSync(t *testing.T) {
+	A := genChannelNodes(t, 5)
+	bootstrapNodes(t, A...)
+	waitForConvergence(t, time.Second, A...)
+
+	B := genChannelNodes(t, 5)
+	bootstrapNodes(t, B...)
+	waitForConvergence(t, time.Second, B...)
+
+	target := B[0].node.Address()
+	A[0].node.disseminator.reverseFullSync(target, time.Second)
+
+	waitForConvergence(t, time.Second, append(A, B...)...)
+}
+
+// TestRedundantFullSync tests wether a RudundantReverseFullSyncEvent is fired
+// when the reverseFullSync didn't apply any changes to the memberlist. We test
+// this by starting a reverseFullSync on a converged healthy cluster.
+func TestRedundantFullSync(t *testing.T) {
+	tnodes := genChannelNodes(t, 5)
+	bootstrapNodes(t, tnodes...)
+	waitForConvergence(t, time.Second, tnodes...)
+
+	quit := make(chan struct{})
+	tnodes[0].node.RegisterListener(on(RedundantReverseFullSyncEvent{}, func() {
+		close(quit)
+	}))
+
+	target := tnodes[1].node.Address()
+	tnodes[0].node.disseminator.reverseFullSync(target, time.Second)
+
+	select {
+	case <-quit:
+	case <-time.After(time.Second):
+		assert.Fail(t, "test timed out")
+	}
+}
+
+// TestReverseFullSyncJoinFailure test the code path for when the join in the
+// reverseFullSync fails. If the app doesn't crash, the test has passed.
+func TestReverseFullSyncJoinFailure(t *testing.T) {
+	tnodes := genChannelNodes(t, 5)
+	bootstrapNodes(t, tnodes...)
+	waitForConvergence(t, time.Second, tnodes...)
+	tnodes[0].node.disseminator.reverseFullSync("XXX", time.Second)
 }

--- a/swim/events.go
+++ b/swim/events.go
@@ -23,6 +23,8 @@ package swim
 import (
 	"time"
 
+	"reflect"
+
 	"github.com/uber/ringpop-go/events"
 )
 
@@ -213,3 +215,29 @@ type RequestBeforeReadyEvent struct {
 
 // A RefuteUpdateEvent is sent when a node detects gossip about its own state that needs to be corrected
 type RefuteUpdateEvent struct{}
+
+// A StartReverseFullSyncEvent is sent when a node starts the reverse full sync procedure
+type StartReverseFullSyncEvent struct {
+	Target string `json:"target"`
+}
+
+// OmitReverseFullSyncEvent is sent when a node omits the reverse full sync
+// prodedure because there are already the max number of reverse full sync
+// processes running.
+type OmitReverseFullSyncEvent struct {
+	Target string `json:"target"`
+}
+
+// RedundantReverseFullSyncEvent is sent when no new changes were added due
+// to the reverse full sync.
+type RedundantReverseFullSyncEvent struct {
+	Target string `json:"target"`
+}
+
+func on(t interface{}, f func()) ListenerFunc {
+	return ListenerFunc(func(e events.Event) {
+		if reflect.TypeOf(t) == reflect.TypeOf(e) {
+			f()
+		}
+	})
+}

--- a/swim/node.go
+++ b/swim/node.go
@@ -52,6 +52,8 @@ type Options struct {
 	RollupFlushInterval time.Duration
 	RollupMaxUpdates    int
 
+	MaxReverseFullSyncJobs int
+
 	Clock clock.Clock
 }
 
@@ -73,6 +75,8 @@ func defaultOptions() *Options {
 		RollupMaxUpdates:    250,
 
 		Clock: clock.New(),
+
+		MaxReverseFullSyncJobs: 5,
 	}
 
 	return opts
@@ -87,21 +91,18 @@ func mergeDefaultOptions(opts *Options) *Options {
 
 	opts.StateTimeouts = mergeStateTimeouts(opts.StateTimeouts, def.StateTimeouts)
 
-	opts.MinProtocolPeriod = util.SelectDuration(opts.MinProtocolPeriod,
-		def.MinProtocolPeriod)
+	opts.MinProtocolPeriod = util.SelectDuration(opts.MinProtocolPeriod, def.MinProtocolPeriod)
 
-	opts.RollupMaxUpdates = util.SelectInt(opts.RollupMaxUpdates,
-		def.RollupMaxUpdates)
-	opts.RollupFlushInterval = util.SelectDuration(opts.RollupFlushInterval,
-		def.RollupFlushInterval)
+	opts.RollupMaxUpdates = util.SelectInt(opts.RollupMaxUpdates, def.RollupMaxUpdates)
+	opts.RollupFlushInterval = util.SelectDuration(opts.RollupFlushInterval, def.RollupFlushInterval)
 
 	opts.JoinTimeout = util.SelectDuration(opts.JoinTimeout, def.JoinTimeout)
 	opts.PingTimeout = util.SelectDuration(opts.PingTimeout, def.PingTimeout)
-	opts.PingRequestTimeout = util.SelectDuration(opts.PingRequestTimeout,
-		def.PingRequestTimeout)
+	opts.PingRequestTimeout = util.SelectDuration(opts.PingRequestTimeout, def.PingRequestTimeout)
 
-	opts.PingRequestSize = util.SelectInt(opts.PingRequestSize,
-		def.PingRequestSize)
+	opts.PingRequestSize = util.SelectInt(opts.PingRequestSize, def.PingRequestSize)
+
+	opts.MaxReverseFullSyncJobs = util.SelectInt(opts.MaxReverseFullSyncJobs, def.MaxReverseFullSyncJobs)
 
 	if opts.Clock == nil {
 		opts.Clock = def.Clock
@@ -148,6 +149,8 @@ type Node struct {
 
 	pingRequestSize int
 
+	maxReverseFullSyncJobs int
+
 	listeners []EventListener
 
 	clientRate metrics.Meter
@@ -179,6 +182,8 @@ func NewNode(app, address string, channel shared.SubChannel, opts *Options) *Nod
 		pingRequestTimeout: opts.PingRequestTimeout,
 
 		pingRequestSize: opts.PingRequestSize,
+
+		maxReverseFullSyncJobs: opts.MaxReverseFullSyncJobs,
 
 		clientRate: metrics.NewMeter(),
 		serverRate: metrics.NewMeter(),

--- a/swim/ping_request_handler.go
+++ b/swim/ping_request_handler.go
@@ -63,12 +63,10 @@ func handlePingRequest(node *Node, req *pingRequest) (*pingResponse, error) {
 		node.memberlist.Update(res.Changes)
 	}
 
-	changes, fullSync :=
+	changes, _ :=
 		node.disseminator.IssueAsReceiver(req.Source, req.SourceIncarnation, req.Checksum)
 
-	if fullSync {
-		// TODO: something...
-	}
+	// ignore full sync
 
 	return &pingResponse{
 		Target:  req.Target,


### PR DESCRIPTION
We throttle the amount of running bidirectional syncers to a configurable amount (default 5).