### PR TITLE
Partition healing

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -31,6 +31,11 @@ type EventListener interface {
 	HandleEvent(event Event)
 }
 
+// EventRegistrar is an object that you can register EventListeners on.
+type EventRegistrar interface {
+	RegisterListener(EventListener)
+}
+
 // A RingChangedEvent is sent when servers are added and/or removed from the ring
 type RingChangedEvent struct {
 	ServersAdded   []string

--- a/ringpop.go
+++ b/ringpop.go
@@ -492,6 +492,12 @@ func (rp *Ringpop) HandleEvent(event events.Event) {
 	case swim.RequestBeforeReadyEvent:
 		rp.statter.IncCounter(rp.getStatKey("not-ready."+string(event.Endpoint)), nil, 1)
 
+	case swim.DiscoHealEvent:
+		rp.statter.IncCounter(rp.getStatKey("heal.triggered"), nil, 1)
+
+	case swim.AttemptHealEvent:
+		rp.statter.IncCounter(rp.getStatKey("heal.attempt"), nil, 1)
+
 	case swim.RefuteUpdateEvent:
 		rp.statter.IncCounter(rp.getStatKey("refuted-update"), nil, 1)
 

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -267,6 +267,12 @@ func (s *RingpopTestSuite) TestHandleEvents() {
 	s.Equal(int64(2), stats.vals["ringpop.127_0_0_1_3001.join.retries"], "join tries didn't update")
 	// expected listener to record 1 event
 
+	s.ringpop.HandleEvent(swim.DiscoHealEvent{})
+	s.Equal(int64(1), stats.vals["ringpop.127_0_0_1_3001.heal.triggered"], "missing stats for received pings")
+
+	s.ringpop.HandleEvent(swim.AttemptHealEvent{})
+	s.Equal(int64(1), stats.vals["ringpop.127_0_0_1_3001.heal.attempt"], "missing stats for received pings")
+
 	s.ringpop.HandleEvent(events.LookupEvent{
 		Key:      "hello",
 		Duration: time.Second,
@@ -384,7 +390,7 @@ func (s *RingpopTestSuite) TestHandleEvents() {
 	// expected listener to record 1 event
 
 	time.Sleep(time.Millisecond) // sleep for a bit so that events can be recorded
-	s.Equal(46, listener.EventCount(), "incorrect count for emitted events")
+	s.Equal(48, listener.EventCount(), "incorrect count for emitted events")
 }
 
 func (s *RingpopTestSuite) TestRingpopReady() {

--- a/swim/disseminator.go
+++ b/swim/disseminator.go
@@ -104,7 +104,7 @@ func (d *disseminator) HasChanges() bool {
 	return result
 }
 
-func (d *disseminator) FullSync() (changes []Change) {
+func (d *disseminator) MembershipAsChanges() (changes []Change) {
 	d.Lock()
 
 	for _, member := range d.node.memberlist.GetMembers() {
@@ -177,7 +177,7 @@ func (d *disseminator) IssueAsReceiver(
 		"remoteChecksum": senderChecksum,
 	}).Info("full sync")
 
-	return d.FullSync(), true
+	return d.MembershipAsChanges(), true
 }
 
 // filterChangesFromSender returns changes that didn't originate at the sender.

--- a/swim/disseminator_test.go
+++ b/swim/disseminator_test.go
@@ -390,7 +390,7 @@ func TestBidirectionalFullSync(t *testing.T) {
 
 	// only when a reverse full sync is issued the membership of b changes
 	// we listen for a membership change and continue the main thread of the test
-	b.node.RegisterListener(on(MemberlistChangesAppliedEvent{}, func() {
+	b.node.RegisterListener(on(MemberlistChangesAppliedEvent{}, func(e Event) {
 		cont <- struct{}{}
 	}))
 
@@ -431,14 +431,14 @@ func TestThrottleBidirectionalFullSyncs(t *testing.T) {
 	total := int64(0)
 
 	// Block the reverse full sync procedure to test if we throttle correctly.
-	tnode.node.RegisterListener(on(StartReverseFullSyncEvent{}, func() {
+	tnode.node.RegisterListener(on(StartReverseFullSyncEvent{}, func(e Event) {
 		atomic.AddInt64(&total, 1)
 		<-block
 	}))
 
 	// Listen for a reverse full sync that is omitted because the max number of
 	// reverse full sync routines are running.
-	tnode.node.RegisterListener(on(OmitReverseFullSyncEvent{}, func() {
+	tnode.node.RegisterListener(on(OmitReverseFullSyncEvent{}, func(e Event) {
 		go func() {
 			for i := 0; i < maxJobs; i++ {
 				block <- struct{}{}
@@ -493,7 +493,7 @@ func TestRedundantFullSync(t *testing.T) {
 	waitForConvergence(t, time.Second, tnodes...)
 
 	quit := make(chan struct{})
-	tnodes[0].node.RegisterListener(on(RedundantReverseFullSyncEvent{}, func() {
+	tnodes[0].node.RegisterListener(on(RedundantReverseFullSyncEvent{}, func(e Event) {
 		close(quit)
 	}))
 

--- a/swim/disseminator_test.go
+++ b/swim/disseminator_test.go
@@ -373,8 +373,8 @@ func TestBidirectionalFullSync(t *testing.T) {
 	b := newChannelNode(t)
 	defer b.Destroy()
 
-	// after bootstrap a's memberlist contains a and b,
-	// but b's membership only contains b.
+	// After bootstrap, a's memberlist contains a and b, but b's membership
+	// only contains b.
 	bootstrapNodes(t, b, a)
 
 	// clear changes so that a full sync will be issued

--- a/swim/disseminator_test.go
+++ b/swim/disseminator_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber/ringpop-go/events"
 	"github.com/uber/ringpop-go/util"
 )
 
@@ -112,7 +113,7 @@ func (s *DisseminatorTestSuite) TestChangesAreCleared() {
 	s.Equal(0, s.d.ChangesCount(), "expected no problems deleting non-existent changes")
 }
 
-func (s *DisseminatorTestSuite) TestFullSync() {
+func (s *DisseminatorTestSuite) TestMembershipAsChanges() {
 	addresses := fakeHostPorts(1, 1, 2, 4)
 
 	for _, address := range addresses {
@@ -390,7 +391,7 @@ func TestBidirectionalFullSync(t *testing.T) {
 
 	// only when a reverse full sync is issued the membership of b changes
 	// we listen for a membership change and continue the main thread of the test
-	b.node.RegisterListener(on(MemberlistChangesAppliedEvent{}, func(e Event) {
+	b.node.RegisterListener(on(MemberlistChangesAppliedEvent{}, func(e events.Event) {
 		cont <- struct{}{}
 	}))
 
@@ -431,14 +432,14 @@ func TestThrottleBidirectionalFullSyncs(t *testing.T) {
 	total := int64(0)
 
 	// Block the reverse full sync procedure to test if we throttle correctly.
-	tnode.node.RegisterListener(on(StartReverseFullSyncEvent{}, func(e Event) {
+	tnode.node.RegisterListener(on(StartReverseFullSyncEvent{}, func(e events.Event) {
 		atomic.AddInt64(&total, 1)
 		<-block
 	}))
 
 	// Listen for a reverse full sync that is omitted because the max number of
 	// reverse full sync routines are running.
-	tnode.node.RegisterListener(on(OmitReverseFullSyncEvent{}, func(e Event) {
+	tnode.node.RegisterListener(on(OmitReverseFullSyncEvent{}, func(e events.Event) {
 		go func() {
 			for i := 0; i < maxJobs; i++ {
 				block <- struct{}{}
@@ -493,7 +494,7 @@ func TestRedundantFullSync(t *testing.T) {
 	waitForConvergence(t, time.Second, tnodes...)
 
 	quit := make(chan struct{})
-	tnodes[0].node.RegisterListener(on(RedundantReverseFullSyncEvent{}, func(e Event) {
+	tnodes[0].node.RegisterListener(on(RedundantReverseFullSyncEvent{}, func(e events.Event) {
 		close(quit)
 	}))
 

--- a/swim/disseminator_test.go
+++ b/swim/disseminator_test.go
@@ -119,7 +119,7 @@ func (s *DisseminatorTestSuite) TestFullSync() {
 		s.m.MakeAlive(address, s.incarnation)
 	}
 
-	changes := s.d.FullSync()
+	changes := s.d.MembershipAsChanges()
 
 	s.Len(changes, 4, "expected to get change for each member")
 }
@@ -508,7 +508,7 @@ func TestRedundantFullSync(t *testing.T) {
 }
 
 // TestReverseFullSyncJoinFailure test the code path for when the join in the
-// reverseFullSync fails. If the app doesn't crash, the test has passed.
+// reverseFullSync fails.
 func TestReverseFullSyncJoinFailure(t *testing.T) {
 	tnodes := genChannelNodes(t, 5)
 	bootstrapNodes(t, tnodes...)

--- a/swim/events.go
+++ b/swim/events.go
@@ -244,33 +244,3 @@ func on(t interface{}, f func(e events.Event)) ListenerFunc {
 		}
 	})
 }
-
-// ExecuteThenWaitFor executes a function and then waits for a specific type
-// of event to occur.
-//
-// Often we want to execute some code and then wait for an event be emitted due
-// to the code being executed. However in order to not miss the event we must
-// first register an event handler before we can execute the code:
-// - register listener that signals we can continue on receiving the correct event;
-// - execute the code that will lead to an event being emitted;
-// - wait for the continue signal.
-//
-// This can be quite hard to follow. Ideally we want it to look like
-// - execute the code that will lead to an event being emitted;
-// - and then wait for a specific event.
-//
-// This function helps with making the code read like the latter.
-func ExecuteThenWaitFor(f func(), er events.EventRegistrar, t interface{}) {
-	block := make(chan struct{})
-
-	er.RegisterListener(on(t, func(e events.Event) {
-		select {
-		case <-block: // channel is closed, do nothing
-		default:
-			close(block)
-		}
-	}))
-
-	f()
-	<-block
-}

--- a/swim/events.go
+++ b/swim/events.go
@@ -28,6 +28,8 @@ import (
 	"github.com/uber/ringpop-go/events"
 )
 
+type Event interface{}
+
 // An EventListener handles events given to it by the SWIM node. HandleEvent should be thread safe.
 type EventListener interface {
 	HandleEvent(events.Event)
@@ -247,10 +249,10 @@ type EventRegistrar interface {
 
 // on is returns an EventListener that executes a function f upon receiving an
 // event of type t.
-func on(t interface{}, f func()) ListenerFunc {
+func on(t interface{}, f func(e Event)) ListenerFunc {
 	return ListenerFunc(func(e events.Event) {
 		if reflect.TypeOf(t) == reflect.TypeOf(e) {
-			f()
+			f(e)
 		}
 	})
 }
@@ -273,7 +275,7 @@ func on(t interface{}, f func()) ListenerFunc {
 func ExecuteThenWaitFor(f func(), er EventRegistrar, t interface{}) {
 	block := make(chan struct{})
 
-	er.RegisterListener(on(t, func() {
+	er.RegisterListener(on(t, func(e Event) {
 		close(block)
 	}))
 

--- a/swim/events.go
+++ b/swim/events.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber/ringpop-go/events"
 )
 
+// Event interface
 type Event interface{}
 
 // An EventListener handles events given to it by the SWIM node. HandleEvent should be thread safe.

--- a/swim/events.go
+++ b/swim/events.go
@@ -234,7 +234,7 @@ type RedundantReverseFullSyncEvent struct {
 	Target string `json:"target"`
 }
 
-// AttemptHealEvent is sent when the discover provider healer attempts to heal a partition
+// DiscoHealEvent is sent when the discover provider healer attempts to heal a partition
 type DiscoHealEvent struct{}
 
 // AttemptHealEvent is sent when the healer is triggered

--- a/swim/gossip_test.go
+++ b/swim/gossip_test.go
@@ -81,7 +81,7 @@ func (s *GossipTestSuite) TestUpdatesArePropagated() {
 	defer peer.channel.Close()
 
 	bootstrapNodes(s.T(), s.tnode, peer)
-	waitForConvergence(s.T(), 500*time.Millisecond, peer)
+	waitForConvergence(s.T(), 500*time.Millisecond, s.tnode, peer)
 	s.True(s.g.Stopped())
 	s.True(peer.node.gossip.Stopped())
 

--- a/swim/handlers.go
+++ b/swim/handlers.go
@@ -51,6 +51,7 @@ type Status struct {
 // HealResponse contains a list of nodes where healing was attempted
 type HealResponse struct {
 	Targets []string `json:"targets"`
+	Error   error    `json:"error"`
 }
 
 // notImplementedHandler is a dummy handler that returns an error explaining
@@ -122,7 +123,8 @@ func (n *Node) gossipHandlerStop(ctx json.Context, req *emptyArg) (*emptyArg, er
 }
 
 func (n *Node) discoverProviderHealerHandler(ctx json.Context, req *emptyArg) (*HealResponse, error) {
-	return &HealResponse{n.healer.Heal()}, nil
+	targets, err := n.healer.Heal()
+	return &HealResponse{Targets: targets, Error: err}, nil
 }
 
 func (n *Node) tickHandler(ctx json.Context, req *emptyArg) (*ping, error) {

--- a/swim/handlers.go
+++ b/swim/handlers.go
@@ -51,7 +51,7 @@ type Status struct {
 // HealResponse contains a list of nodes where healing was attempted
 type HealResponse struct {
 	Targets []string `json:"targets"`
-	Error   error    `json:"error"`
+	Error   string   `json:"error"`
 }
 
 // notImplementedHandler is a dummy handler that returns an error explaining
@@ -124,7 +124,7 @@ func (n *Node) gossipHandlerStop(ctx json.Context, req *emptyArg) (*emptyArg, er
 
 func (n *Node) discoverProviderHealerHandler(ctx json.Context, req *emptyArg) (*HealResponse, error) {
 	targets, err := n.healer.Heal()
-	return &HealResponse{Targets: targets, Error: err}, nil
+	return &HealResponse{Targets: targets, Error: err.Error()}, nil
 }
 
 func (n *Node) tickHandler(ctx json.Context, req *emptyArg) (*ping, error) {

--- a/swim/handlers.go
+++ b/swim/handlers.go
@@ -48,7 +48,7 @@ type Status struct {
 	Status string `json:"status"`
 }
 
-// HealStatus contains a list of nodes where healing was attempted
+// HealResponse contains a list of nodes where healing was attempted
 type HealResponse struct {
 	Targets []string `json:"targets"`
 }

--- a/swim/handlers.go
+++ b/swim/handlers.go
@@ -69,7 +69,7 @@ func (n *Node) registerHandlers() error {
 		"/admin/gossip":              n.gossipHandler, // Deprecated
 		"/admin/gossip/start":        n.gossipHandlerStart,
 		"/admin/gossip/stop":         n.gossipHandlerStop,
-		"/admin/healpartition/disco": n.partitionHealerHandler,
+		"/admin/healpartition/disco": n.discoverProviderHealerHandler,
 		"/admin/tick":                n.tickHandler, // Deprecated
 		"/admin/gossip/tick":         n.tickHandler,
 		"/admin/member/leave":        n.adminLeaveHandler,
@@ -121,7 +121,7 @@ func (n *Node) gossipHandlerStop(ctx json.Context, req *emptyArg) (*emptyArg, er
 	return &emptyArg{}, nil
 }
 
-func (n *Node) partitionHealerHandler(ctx json.Context, req *emptyArg) (*HealResponse, error) {
+func (n *Node) discoverProviderHealerHandler(ctx json.Context, req *emptyArg) (*HealResponse, error) {
 	return &HealResponse{n.healer.Heal()}, nil
 }
 

--- a/swim/handlers.go
+++ b/swim/handlers.go
@@ -124,7 +124,11 @@ func (n *Node) gossipHandlerStop(ctx json.Context, req *emptyArg) (*emptyArg, er
 
 func (n *Node) discoverProviderHealerHandler(ctx json.Context, req *emptyArg) (*HealResponse, error) {
 	targets, err := n.healer.Heal()
-	return &HealResponse{Targets: targets, Error: err.Error()}, nil
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	return &HealResponse{Targets: targets, Error: msg}, nil
 }
 
 func (n *Node) tickHandler(ctx json.Context, req *emptyArg) (*ping, error) {

--- a/swim/handlers_test.go
+++ b/swim/handlers_test.go
@@ -95,7 +95,7 @@ func (s *HandlerTestSuite) TestGossipStopHandler() {
 func (s *HandlerTestSuite) TestPartitionHealerHandler() {
 	done := make(chan struct{})
 	go func() {
-		ExecuteThenWaitFor(func() {
+		DoThenWaitFor(func() {
 			_, err := s.testNode.node.discoverProviderHealerHandler(s.ctx, &emptyArg{})
 			s.NoError(err, "calling handler should not result in error")
 		}, s.testNode.node, DiscoHealEvent{})

--- a/swim/handlers_test.go
+++ b/swim/handlers_test.go
@@ -92,6 +92,13 @@ func (s *HandlerTestSuite) TestGossipStopHandler() {
 	s.True(s.testNode.node.gossip.Stopped())
 }
 
+func (s *HandlerTestSuite) TestPartitionHealerHandler() {
+	ExecuteThenWaitFor(func() {
+		_, err := s.testNode.node.partitionHealerHandler(s.ctx, &emptyArg{})
+		s.NoError(err, "calling handler should not result in error")
+	}, s.testNode.node, DiscoHealEvent{})
+}
+
 func (s *HandlerTestSuite) TestToggleGossipHandler() {
 	s.Require().True(s.testNode.node.gossip.Stopped())
 

--- a/swim/heal_partition.go
+++ b/swim/heal_partition.go
@@ -71,7 +71,11 @@ func nodesThatNeedToReincarnate(A, B []Change) (changesForA, changesForB []Chang
 
 		// faulty for partition A, alive for partition B
 		// needs reincarnation in partition B.
-		if a.Status == Faulty && b.Status == Alive && a.Incarnation >= b.Incarnation {
+
+		if statePrecedence(a.Status) >= statePrecedence(Faulty) &&
+			b.Status == Alive &&
+			a.Incarnation >= b.Incarnation {
+
 			changesForB = append(changesForB, Change{
 				Address:     a.Address,
 				Incarnation: a.Incarnation,
@@ -81,7 +85,10 @@ func nodesThatNeedToReincarnate(A, B []Change) (changesForA, changesForB []Chang
 
 		// alive for partition A, faulty for partition B
 		// needs reincarnation in partition A.
-		if a.Status == Alive && b.Status == Faulty && a.Incarnation <= b.Incarnation {
+		if a.Status == Alive &&
+			statePrecedence(b.Status) >= statePrecedence(Faulty) &&
+			a.Incarnation <= b.Incarnation {
+
 			changesForA = append(changesForA, Change{
 				Address:     b.Address,
 				Incarnation: b.Incarnation,

--- a/swim/heal_partition.go
+++ b/swim/heal_partition.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package swim
+
+import "time"
+
+// AttemptHeal attempts to heal a partition between the node and the target.
+//
+// Be mindfull that calling this function will not result in a heal when there
+// are nodes that need to be reincarated to take precedence over the faulty
+// declarations that occur during a network partition. A cluster may therefore
+// need multiple calls to this function with some time in between to heal.
+//
+// Check out ringpop-common/docs for a full description of the algorithm.
+func AttemptHeal(node *Node, target string) error {
+	node.emit(AttemptHealEvent{})
+	node.logger.WithField("target", target).Info("attempt heal")
+
+	// If join request succeeds a partition is detected,
+	// this node will now coordinate the healing mechanism.
+	joinRes, err := sendJoinRequest(node, target, time.Second)
+	if err != nil {
+		return err
+	}
+
+	A := node.disseminator.FullSync()
+	B := joinRes.Membership
+	var csForA, csForB []Change
+
+	// Find changes that are alive for B and faulty for A and visa versa.
+	for _, m2 := range B {
+		m1, ok := selectMember(A, m2.Address)
+		if !ok {
+			continue
+		}
+
+		// faulty for partition A, alive for partition B
+		// needs reincarnation in partition B.
+		if m1.Status == Faulty && m2.Status == Alive && m1.Incarnation >= m2.Incarnation {
+			copy := m1
+			copy.Status = Suspect
+			csForB = append(csForB, copy)
+		}
+
+		// alive for partition A, faulty for partition B
+		// needs reincarnation in partition A.
+		if m1.Status == Alive && m2.Status == Faulty && m1.Incarnation <= m2.Incarnation {
+			copy := m2
+			copy.Status = Suspect
+			csForA = append(csForA, copy)
+		}
+	}
+	// Merge partitions if no node needs to reincarnate,
+	if len(csForA) == 0 && len(csForB) == 0 {
+		// TODO: send out event/log that we are merging
+
+		// Add membership of B to this node, so that the membership
+		// information of B will be disseminated through A.
+		node.memberlist.Update(B)
+
+		// Send membership of A to the target node, so that the membership
+		// information of partition A will be disseminated through B.
+		A1 := node.disseminator.FullSync()
+		_, err := sendPingWithChanges(node, target, A1, time.Second)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// reincarnate all nodes by disseminating that they are suspect
+	// TODO: send out event/log that we are reincarnating
+	node.memberlist.Update(csForA)
+
+	_, err = sendPingWithChanges(node, target, csForB, time.Second)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// selectMember selects the member with the specified address from the partition.
+func selectMember(partition []Change, address string) (Change, bool) {
+	for _, m := range partition {
+		if m.Address == address {
+			return m, true
+		}
+	}
+
+	return Change{}, false
+}

--- a/swim/heal_partition.go
+++ b/swim/heal_partition.go
@@ -70,7 +70,7 @@ func AttemptHeal(node *Node, target string) error {
 	}
 	// Merge partitions if no node needs to reincarnate,
 	if len(csForA) == 0 && len(csForB) == 0 {
-		// TODO: send out event/log that we are merging
+		node.healer.logger.WithField("target", target).Info("merge two partitions")
 
 		// Add membership of B to this node, so that the membership
 		// information of B will be disseminated through A.
@@ -88,7 +88,7 @@ func AttemptHeal(node *Node, target string) error {
 	}
 
 	// reincarnate all nodes by disseminating that they are suspect
-	// TODO: send out event/log that we are reincarnating
+	node.healer.logger.WithField("target", target).Info("reincarnate nodes before we can merge the partitions")
 	node.memberlist.Update(csForA)
 
 	_, err = sendPingWithChanges(node, target, csForB, time.Second)

--- a/swim/heal_partition.go
+++ b/swim/heal_partition.go
@@ -44,22 +44,22 @@ func AttemptHeal(node *Node, target string) ([]string, error) {
 	A := node.disseminator.MembershipAsChanges()
 	B := joinRes.Membership
 
-	// Get the nodes that aren't mergeable and need to reincarnate
+	// Get the nodes that aren't mergeable and need to be reincarnated
 	changesForA, changesForB := nodesThatNeedToReincarnate(A, B)
 
-	// Reincarnate the nodes that need to reincarnate
+	// Reincarnate the nodes that need to be reincarnated
 	if len(changesForA) != 0 || len(changesForB) != 0 {
 		err = reincarnateNodes(node, target, changesForA, changesForB)
 		return aliveHosts(B), err
 	}
 
-	// Merge partitions if no node needs to reincarnate
+	// Merge partitions if no node needs to be reincarnated
 	err = mergePartitions(node, target, B)
 	return aliveHosts(B), err
 }
 
 // nodesThatNeedToReincarnate finds all nodes would become faulty when
-// membership A gets merged with membership B. These need to reincarnate
+// membership A gets merged with membership B. These need to be reincarnated
 // first, before we can heal the partition with a merge.
 func nodesThatNeedToReincarnate(A, B []Change) (changesForA, changesForB []Change) {
 	// Find changes that are alive for B and faulty for A and visa versa.

--- a/swim/heal_partition.go
+++ b/swim/heal_partition.go
@@ -54,7 +54,7 @@ func AttemptHeal(node *Node, target string) ([]string, error) {
 	}
 
 	// Merge partitions if no node needs to reincarnate
-	err = mergePartitions(node, target, A, B)
+	err = mergePartitions(node, target, B)
 	return aliveHosts(B), err
 }
 
@@ -111,7 +111,7 @@ func reincarnateNodes(node *Node, target string, csForA, csForB []Change) error 
 
 // mergePartitions applies the membership of B to a and send the membership
 // A to B piggybacked on top of a ping.
-func mergePartitions(node *Node, target string, A, B []Change) error {
+func mergePartitions(node *Node, target string, B []Change) error {
 	node.healer.logger.WithField("target", target).Info("merge two partitions")
 
 	// Add membership of B to this node, so that the membership
@@ -120,8 +120,8 @@ func mergePartitions(node *Node, target string, A, B []Change) error {
 
 	// Send membership of A to the target node, so that the membership
 	// information of partition A will be disseminated through B.
-	// A1 := node.disseminator.MembershipAsChanges()
-	_, err := sendPingWithChanges(node, target, A, time.Second)
+	A1 := node.disseminator.MembershipAsChanges()
+	_, err := sendPingWithChanges(node, target, A1, time.Second)
 	return err
 }
 

--- a/swim/heal_partition_test.go
+++ b/swim/heal_partition_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/ringpop-go/discovery/statichosts"
+	"github.com/uber/ringpop-go/events"
 )
 
 // TestPartitionHealWithFaulties creates two partitions A and B where A sees B
@@ -299,7 +300,7 @@ func TestHealBeforeBootstrap(t *testing.T) {
 
 	// block a from completing bootstrap
 	block := make(chan struct{})
-	a.node.RegisterListener(on(JoinTriesUpdateEvent{}, func(e Event) {
+	a.node.RegisterListener(on(JoinTriesUpdateEvent{}, func(e events.Event) {
 		<-block
 	}))
 
@@ -307,7 +308,7 @@ func TestHealBeforeBootstrap(t *testing.T) {
 
 	// bootstrap a and wait for it to be in bootstrap phase
 	go func() {
-		_, _ = a.node.Bootstrap(&BootstrapOptions{
+		a.node.Bootstrap(&BootstrapOptions{
 			DiscoverProvider: discoProvider,
 		})
 	}()
@@ -463,7 +464,7 @@ Tick:
 		// continue until all members are reachable
 		for _, node := range nodes {
 			if node.memberlist.CountReachableMembers() != len(nodes) {
-				continue
+				continue Tick
 			}
 		}
 

--- a/swim/heal_partition_test.go
+++ b/swim/heal_partition_test.go
@@ -190,7 +190,7 @@ func TestHealBeforeBootstrap(t *testing.T) {
 		})
 	}()
 
-	// bootstrap b then add a to it's bootstrap provider after
+	// bootstrap b then add a to its bootstrap provider
 	bootstrapNodes(t, b)
 	b.node.discoverProvider = discoProvider
 	b.node.disseminator.ClearChanges()
@@ -208,7 +208,7 @@ func TestHealBeforeBootstrap(t *testing.T) {
 	_, has = b.node.memberlist.Member(a.node.Address())
 	assert.True(t, has, "expected that a is now part of b's membership")
 
-	// make sure that a is still not bootstrapped, this causes a to be suspect to be
+	// make sure that a is still not bootstrapped, this causes a to be suspect to b
 	ExecuteThenWaitFor(func() {
 		b.node.pingNextMember()
 	}, a.node, RequestBeforeReadyEvent{})
@@ -256,8 +256,8 @@ func (p partition) ProgressTime(T time.Duration) {
 	}
 }
 
-// HasPartitionAs checks that every node from A, contains every node from B in its
-// membership. It also checks that the members from B have the correct
+// HasPartitionAs checks that every node from A contains every node from B in
+// its membership. It also checks that the members from B have the correct
 // incarnation number and status.
 func (p partition) HasPartitionAs(t *testing.T, B partition, incarnation int64, status string) {
 	for _, a := range p {

--- a/swim/heal_partition_test.go
+++ b/swim/heal_partition_test.go
@@ -21,7 +21,6 @@
 package swim
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -238,7 +237,6 @@ func TestPartitionHealWithMultiplePartitions(t *testing.T) {
 	A[0].node.discoverProvider = statichosts.New(hosts...)
 
 	targets := A[0].node.healer.Heal()
-	fmt.Println(targets)
 	assert.Len(t, targets, 5, "expected correct amount of targets")
 
 	waitForConvergence(t, time.Second, A...)
@@ -251,7 +249,6 @@ func TestPartitionHealWithMultiplePartitions(t *testing.T) {
 	}
 
 	targets = A[0].node.healer.Heal()
-	fmt.Println(targets)
 	assert.Len(t, targets, 4, "expected correct amount of targets")
 
 	waitForPartitionHeal(t, time.Second, append(Bs, A)...)

--- a/swim/heal_partition_test.go
+++ b/swim/heal_partition_test.go
@@ -272,7 +272,7 @@ func TestHealBeforeBootstrap(t *testing.T) {
 
 	// block a from completing bootstrap
 	block := make(chan struct{})
-	a.node.RegisterListener(on(JoinTriesUpdateEvent{}, func() {
+	a.node.RegisterListener(on(JoinTriesUpdateEvent{}, func(e Event) {
 		<-block
 	}))
 

--- a/swim/heal_partition_test.go
+++ b/swim/heal_partition_test.go
@@ -21,7 +21,6 @@
 package swim
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -369,15 +368,17 @@ func (p partition) HasPartitionAs(t *testing.T, B partition, incarnation int64, 
 	}
 }
 
-func (p partition) DoesNotContain(t *testing.T, B partition) {
-	for _, a := range p {
-		for _, b := range B {
-			_, ok := a.node.memberlist.Member(b.node.Address())
-			assert.False(t, ok, "expected memberlist to not contain member")
-		}
-	}
-}
+//
+// func (p partition) DoesNotContain(t *testing.T, B partition) {
+// 	for _, a := range p {
+// 		for _, b := range B {
+// 			_, ok := a.node.memberlist.Member(b.node.Address())
+// 			assert.False(t, ok, "expected memberlist to not contain member")
+// 		}
+// 	}
+// }
 
+// Hosts the string slice of addresses for all the nodes in the partition.
 func (p partition) Hosts() []string {
 	var res []string
 	for _, a := range p {
@@ -386,16 +387,8 @@ func (p partition) Hosts() []string {
 	return res
 }
 
-func (p partition) String() string {
-	r := ""
-	mems := p[0].node.memberlist.GetMembers()
-	for i := range mems {
-		r += fmt.Sprintln(mems[i].Address, mems[i].Incarnation, mems[i].Status)
-	}
-	r += fmt.Sprintln()
-	return r
-}
-
+// Contains tells whether a node with the specified address is part of the
+// partition.
 func (p partition) Contains(address string) bool {
 	for _, a := range p {
 		if a.node.Address() == address {
@@ -405,7 +398,7 @@ func (p partition) Contains(address string) bool {
 	return false
 }
 
-// waitForPartitionHeal let's the nodes of all partitions gossip and returns
+// waitForPartitionHeal lets the nodes of all partitions gossip and returns
 // when the nodes are converged. After the cluster finished gossipping we
 // double check that all nodes have the same checksum for the memberlist,
 // this means that the cluster is converged and healed.

--- a/swim/heal_partition_test.go
+++ b/swim/heal_partition_test.go
@@ -100,9 +100,7 @@ func TestPartitionHealWithFaultyAndMissing(t *testing.T) {
 	A.ProgressTime(time.Millisecond * 3)
 	B.ProgressTime(time.Millisecond * 5)
 
-	// A.AddPartitionWithStatus(B1, Suspect)
 	A.AddPartitionWithStatus(B1, Faulty)
-	// B.AddPartitionWithStatus(A1, Suspect)
 	B.AddPartitionWithStatus(A1, Faulty)
 
 	waitForConvergence(t, 3*time.Second, A...)
@@ -165,9 +163,8 @@ func TestPartitionHealWithTime(t *testing.T) {
 // TestHealBeforeBootstrap tests that we can heal with a node that is still
 // bootstrapping. We put a node in the bootstrapping phase by giving it a
 // host-list that is impossible to join. When it is in this phase, we trigger
-// a heal attempt from another node. The heal should succeed from b's
-// perspective. Healing from bootstrap is very similar to joining a node that
-// is in the bootstrapping phase.
+// a heal attempt from another node. The heal should succeed from the other
+// node's perspective.
 func TestHealBeforeBootstrap(t *testing.T) {
 	a := newChannelNode(t)
 	defer a.Destroy()
@@ -306,8 +303,10 @@ func (p partition) Contains(address string) bool {
 	return false
 }
 
-// waitForPartitionHeal is same as waitForConvergence but unlike that function,
-// waitForPatitionHeal doesn't stop when no dissemination is detected.
+// waitForPartitionHeal let's the nodes of all partitions gossip and returns
+// when the nodes are converged. After the cluster finished gossipping we
+// double check that all nodes have the same checksum for the memberlist,
+// this means that the cluster is converged and healed.
 func waitForPartitionHeal(t *testing.T, timeout time.Duration, ps ...partition) {
 	var nodes []*Node
 	for _, p := range ps {

--- a/swim/heal_partition_test.go
+++ b/swim/heal_partition_test.go
@@ -289,8 +289,9 @@ func (p partition) Hosts() []string {
 
 func (p partition) String() string {
 	r := ""
-	for _, m := range p[0].node.memberlist.GetMembers() {
-		r += fmt.Sprintln(m.Address, m.Incarnation, m.Status)
+	mems := p[0].node.memberlist.GetMembers()
+	for i := range mems {
+		r += fmt.Sprintln(mems[i].Address, mems[i].Incarnation, mems[i].Status)
 	}
 	r += fmt.Sprintln()
 	return r

--- a/swim/heal_partition_test.go
+++ b/swim/heal_partition_test.go
@@ -1,0 +1,343 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package swim
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/ringpop-go/discovery/statichosts"
+)
+
+func TestPartitionHealWithFaulties(t *testing.T) {
+	A := newPartition(t, 5)
+	B := newPartition(t, 5)
+	defer destroyNodes(A...)
+	defer destroyNodes(B...)
+
+	A.AddPartitionWithStatus(B, Faulty)
+	B.AddPartitionWithStatus(A, Faulty)
+
+	A.ProgressTime(time.Millisecond * 3)
+	B.ProgressTime(time.Millisecond * 5)
+
+	A[0].node.discoverProvider = statichosts.New(append(A.Hosts(), B.Hosts()...)...)
+
+	targets := A[0].node.healer.Heal()
+	assert.Len(t, targets, 1, "expected correct amount of targets")
+	assert.True(t, B.Contains(targets[0]), "expected target to be a node from the right partition")
+
+	waitForConvergence(t, 3*time.Second, A...)
+	waitForConvergence(t, 3*time.Second, B...)
+
+	A.HasPartitionAs(t, A, 3, "alive")
+	A.HasPartitionAs(t, B, 0, "faulty")
+	B.HasPartitionAs(t, B, 5, "alive")
+	B.HasPartitionAs(t, A, 0, "faulty")
+
+	targets = A[0].node.healer.Heal()
+	assert.Len(t, targets, 1, "expected correct amount of targets")
+	assert.True(t, B.Contains(targets[0]), "expected target to be a node from the right partition")
+
+	waitForPartitionHeal(t, time.Second*3, A, B)
+
+	A.HasPartitionAs(t, A, 3, "alive")
+	A.HasPartitionAs(t, B, 5, "alive")
+	B.HasPartitionAs(t, B, 5, "alive")
+	B.HasPartitionAs(t, A, 3, "alive")
+}
+
+func TestPartitionHealWithMissing(t *testing.T) {
+	A := newPartition(t, 5)
+	B := newPartition(t, 5)
+	defer destroyNodes(A...)
+	defer destroyNodes(B...)
+
+	A[0].node.discoverProvider = statichosts.New(append(A.Hosts(), B.Hosts()...)...)
+
+	targets := A[0].node.healer.Heal()
+	assert.Len(t, targets, 1, "expected correct amount of targets")
+	assert.True(t, B.Contains(targets[0]), "expected target to be a node from the right partition")
+
+	waitForPartitionHeal(t, time.Second*3, A, B)
+
+	A.HasPartitionAs(t, A, 0, "alive")
+	A.HasPartitionAs(t, B, 0, "alive")
+	B.HasPartitionAs(t, B, 0, "alive")
+	B.HasPartitionAs(t, A, 0, "alive")
+}
+
+func TestPartitionHealWithFaultyAndMissing(t *testing.T) {
+	A := newPartition(t, 6)
+	A1 := partition(A[0:3])
+	defer destroyNodes(A...)
+
+	B := newPartition(t, 6)
+	B1 := partition(B[0:3])
+	defer destroyNodes(B...)
+
+	A.ProgressTime(time.Millisecond * 3)
+	B.ProgressTime(time.Millisecond * 5)
+
+	// A.AddPartitionWithStatus(B1, Suspect)
+	A.AddPartitionWithStatus(B1, Faulty)
+	// B.AddPartitionWithStatus(A1, Suspect)
+	B.AddPartitionWithStatus(A1, Faulty)
+
+	waitForConvergence(t, 3*time.Second, A...)
+	waitForConvergence(t, 3*time.Second, B...)
+
+	A[0].node.discoverProvider = statichosts.New(append(A.Hosts(), B.Hosts()...)...)
+	A[0].node.healer.Heal()
+	waitForConvergence(t, 3*time.Second, A...)
+	waitForConvergence(t, 3*time.Second, B...)
+
+	A[0].node.healer.Heal()
+	waitForPartitionHeal(t, time.Second*3, A, B)
+}
+
+// TestPartitionHealSemiPartition checks if the ring cluster automatically
+// recovers when half partitioned. The bidirectional full sync mechanism
+// is responsible to heal partitions of this form. We test for this because
+// the partition healing mechanism could leave the cluster in this state
+// when it completes only partially.
+func TestPartitionHealSemiParition(t *testing.T) {
+	A := newPartition(t, 5)
+	B := newPartition(t, 5)
+	defer destroyNodes(A...)
+	defer destroyNodes(B...)
+
+	A.AddPartitionWithStatus(B, Alive)
+
+	waitForPartitionHeal(t, time.Second*3, A, B)
+}
+
+func TestPartitionHealWithTime(t *testing.T) {
+	A := newPartition(t, 5)
+	B := newPartition(t, 5)
+	defer destroyNodes(A...)
+	defer destroyNodes(B...)
+
+	A.AddPartitionWithStatus(B, Faulty)
+	B.AddPartitionWithStatus(A, Faulty)
+
+	A.ProgressTime(time.Millisecond)
+	B.ProgressTime(time.Millisecond)
+
+	A[0].node.discoverProvider = statichosts.New(append(A.Hosts(), B.Hosts()...)...)
+
+	A[0].node.healer.Start()
+
+	// Progress time in a background thread. This will cause the node to
+	// attempt a heal periodically.
+	c := clock.NewMock()
+	A[0].node.clock = c
+	go func() {
+		for {
+			c.Add(time.Second)
+		}
+	}()
+
+	waitForPartitionHeal(t, 3000*time.Millisecond, A, B)
+}
+
+// TestHealBeforeBootstrap tests that we can heal with a node that is still
+// bootstrapping. We put a node in the bootstrapping phase by giving it a
+// host-list that is impossible to join. When it is in this phase, we trigger
+// a heal attempt from another node. The heal should succeed from b's
+// perspective. Healing from bootstrap is very similar to joining a node that
+// is in the bootstrapping phase.
+func TestHealBeforeBootstrap(t *testing.T) {
+	a := newChannelNode(t)
+	defer a.Destroy()
+
+	b := newChannelNode(t)
+	defer b.Destroy()
+
+	// block a from completing bootstrap
+	block := make(chan struct{})
+	a.node.RegisterListener(on(JoinTriesUpdateEvent{}, func() {
+		<-block
+	}))
+
+	discoProvider := statichosts.New(a.node.Address(), b.node.Address())
+
+	// bootstrap a and wait for it to be in bootstrap phase
+	go func() {
+		_, _ = a.node.Bootstrap(&BootstrapOptions{
+			DiscoverProvider: discoProvider,
+		})
+	}()
+
+	// bootstrap b then add a to it's bootstrap provider after
+	bootstrapNodes(t, b)
+	b.node.discoverProvider = discoProvider
+	b.node.disseminator.ClearChanges()
+
+	// check that a is not yet part of b's membership
+	_, has := b.node.memberlist.Member(a.node.Address())
+	assert.False(t, has, "expected that a is not yet part of b's membership")
+
+	// start heal
+	targets := b.node.healer.Heal()
+	assert.Len(t, targets, 1, "expected that b healed with node node a")
+	assert.Equal(t, a.node.Address(), targets[0], "expected b healed with node a")
+
+	// a is now part of b's membership
+	_, has = b.node.memberlist.Member(a.node.Address())
+	assert.True(t, has, "expected that a is now part of b's membership")
+
+	// make sure that a is still not bootstrapped, this causes a to be suspect to be
+	ExecuteThenWaitFor(func() {
+		b.node.pingNextMember()
+	}, a.node, RequestBeforeReadyEvent{})
+
+	// allows a to bootstrap
+	ExecuteThenWaitFor(func() {
+		close(block)
+	}, a.node, JoinCompleteEvent{})
+
+	// progress timers so that incarnation numbers can bump
+	c := clock.NewMock()
+	c.Add(time.Millisecond)
+	a.node.clock = c
+
+	waitForConvergence(t, time.Second*3, a, b)
+}
+
+type partition []*testNode
+
+func newPartition(t *testing.T, n int) partition {
+	p := partition(genChannelNodes(t, n))
+	bootstrapNodes(t, p...)
+	waitForConvergence(t, 500*time.Millisecond, p...)
+	return p
+}
+
+func (p partition) AddPartitionWithStatus(B partition, status string) {
+	for _, n := range p {
+		for _, n2 := range B {
+			n.node.memberlist.MakeChange(n2.node.Address(), n2.node.Incarnation(), status)
+		}
+	}
+
+	for _, n := range p {
+		n.node.disseminator.ClearChanges()
+	}
+}
+
+func (p partition) ProgressTime(T time.Duration) {
+	for _, n := range p {
+		now := n.node.clock.Now()
+		c := clock.NewMock()
+		c.Add(now.Add(T).Sub(clock.NewMock().Now()))
+		n.node.clock = c
+	}
+}
+
+// HasPartitionAs checks that every node from A, contains every node from B in its
+// membership. It also checks that the members from B have the correct
+// incarnation number and status.
+func (p partition) HasPartitionAs(t *testing.T, B partition, incarnation int64, status string) {
+	for _, a := range p {
+		for _, b := range B {
+			mem, ok := a.node.memberlist.Member(b.node.Address())
+			assert.True(t, ok, "expected members to contain member")
+			assert.Equal(t, incarnation, mem.Incarnation, "expected correct incarnation number")
+			assert.Equal(t, status, mem.Status, "expected correct status")
+		}
+	}
+}
+
+func (p partition) DoesNotContain(t *testing.T, B partition) {
+	for _, a := range p {
+		for _, b := range B {
+			_, ok := a.node.memberlist.Member(b.node.Address())
+			assert.False(t, ok, "expected memberlist to not contain member")
+		}
+	}
+}
+
+func (p partition) Hosts() []string {
+	var res []string
+	for _, a := range p {
+		res = append(res, a.node.Address())
+	}
+	return res
+}
+
+func (p partition) String() string {
+	r := ""
+	for _, m := range p[0].node.memberlist.GetMembers() {
+		r += fmt.Sprintln(m.Address, m.Incarnation, m.Status)
+	}
+	r += fmt.Sprintln()
+	return r
+}
+
+func (p partition) Contains(address string) bool {
+	for _, a := range p {
+		if a.node.Address() == address {
+			return true
+		}
+	}
+	return false
+}
+
+// waitForPartitionHeal is same as waitForConvergence but unlike that function,
+// waitForPatitionHeal doesn't stop when no dissemination is detected.
+func waitForPartitionHeal(t *testing.T, timeout time.Duration, ps ...partition) {
+	var nodes []*Node
+	for _, p := range ps {
+		nodes = append(nodes, testNodesToNodes(p)...)
+	}
+
+	deadline := time.Now().Add(timeout)
+
+Tick:
+	for {
+		// check deadline
+		if time.Now().After(deadline) {
+			t.Errorf("timeout during wait for convergence")
+			return
+		}
+
+		// let nodes gossip
+		for _, node := range nodes {
+			node.gossip.ProtocolPeriod()
+		}
+
+		// continue until there are no more changes
+		for _, node := range nodes {
+			if node.HasChanges() {
+				continue Tick
+			}
+		}
+
+		// return when converged
+		if nodesConverged(nodes) {
+			return
+		}
+	}
+}

--- a/swim/heal_partition_test.go
+++ b/swim/heal_partition_test.go
@@ -275,11 +275,13 @@ func TestPartitionHealWithTime(t *testing.T) {
 
 	// Progress time in a background thread. This will cause the node to
 	// attempt a heal periodically.
+
 	c := clock.NewMock()
 	A[0].node.clock = c
 	go func() {
 		for {
-			c.Add(time.Second)
+			c.Add(A[0].node.healer.period)
+			time.Sleep(time.Millisecond)
 		}
 	}()
 
@@ -331,12 +333,12 @@ func TestHealBeforeBootstrap(t *testing.T) {
 	assert.True(t, has, "expected that a is now part of b's membership")
 
 	// make sure that a is still not bootstrapped, this causes a to be suspect to b
-	ExecuteThenWaitFor(func() {
+	DoThenWaitFor(func() {
 		b.node.pingNextMember()
 	}, a.node, RequestBeforeReadyEvent{})
 
 	// allows a to bootstrap
-	ExecuteThenWaitFor(func() {
+	DoThenWaitFor(func() {
 		close(block)
 	}, a.node, JoinCompleteEvent{})
 

--- a/swim/heal_partition_test.go
+++ b/swim/heal_partition_test.go
@@ -296,8 +296,7 @@ func TestHealBeforeBootstrap(t *testing.T) {
 
 	// start heal
 	targets := b.node.healer.Heal()
-	assert.Len(t, targets, 1, "expected that b healed with node node a")
-	assert.Equal(t, a.node.Address(), targets[0], "expected b healed with node a")
+	assert.Len(t, targets, 0, "expected that b cannot completely heal with a")
 
 	// a is now part of b's membership
 	_, has = b.node.memberlist.Member(a.node.Address())

--- a/swim/heal_via_discover_provider.go
+++ b/swim/heal_via_discover_provider.go
@@ -62,9 +62,7 @@ func (h *discoverProviderHealer) Start() {
 	go func() {
 		for {
 			// attempt heal with the pro
-			p := rand.Float64()
-			P := h.Probability()
-			if p < P {
+			if rand.Float64() < h.Probability() {
 				h.Heal()
 			}
 

--- a/swim/heal_via_discover_provider.go
+++ b/swim/heal_via_discover_provider.go
@@ -148,3 +148,17 @@ func (h *discoverProviderHealer) Heal() []string {
 
 	return ret
 }
+
+// del returns a slice where all ocurences of s are filtered out. This modifies
+// the original slice.
+func del(strs []string, s string) []string {
+	for i := 0; i < len(strs); i++ {
+		if strs[i] != s {
+			continue
+		}
+		strs[i] = strs[len(strs)-1]
+		strs = strs[:len(strs)-1]
+		i--
+	}
+	return strs
+}

--- a/swim/heal_via_discover_provider.go
+++ b/swim/heal_via_discover_provider.go
@@ -61,6 +61,7 @@ func newDiscoverProviderHealer(n *Node, baseProbability float64, period time.Dur
 
 // Start the partition healing loop
 func (h *discoverProviderHealer) Start() {
+	rand.Seed(time.Now().UnixNano())
 	// check if started channel is already filled
 	// if not, we start a new loop
 	select {

--- a/swim/heal_via_discover_provider.go
+++ b/swim/heal_via_discover_provider.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package swim
+
+import (
+	"math/rand"
+	"time"
+
+	log "github.com/uber-common/bark"
+	"github.com/uber/ringpop-go/discovery"
+	"github.com/uber/ringpop-go/logging"
+)
+
+// discoverProviderHealer attempts to heal a ringpop partition by consulting
+// the discoverProvider for nodes that are faulty or not available in its
+// membership. It attempts the heal probabalisticly so that the discovery provider
+// doesn't get overloaded with request -- with default settings 6
+// times per minutes on avarage for the entire cluster.
+type discoverProviderHealer struct {
+	node *Node
+
+	discoverProvider *discovery.DiscoverProvider
+	baseProbabillity float64
+	period           time.Duration
+
+	previousHostListSize int
+	quit                 chan bool
+
+	logger log.Logger
+}
+
+func newDiscoverProviderHealer(n *Node, baseProbability float64, period time.Duration) *discoverProviderHealer {
+	return &discoverProviderHealer{
+		node:             n,
+		baseProbabillity: baseProbability,
+		period:           period,
+		quit:             make(chan bool, 1),
+		logger:           logging.Logger("healer").WithField("local", n.Address()),
+	}
+}
+
+// Start the partition healing loop
+func (h *discoverProviderHealer) Start() {
+	go func() {
+		for {
+			// attempt heal with the pro
+			p := rand.Float64()
+			P := h.Probability()
+			if p < P {
+				h.Heal()
+			}
+
+			// loop or quit
+			select {
+			case <-h.node.clock.After(h.period):
+			case <-h.quit:
+				return
+			}
+		}
+	}()
+}
+
+// Stop the partition healing loop
+func (h *discoverProviderHealer) Stop() {
+	h.quit <- true
+}
+
+// Probability returns the probability when a heal should be attempted
+// we want to throttle the heal attempts to alleviate pressure on the
+// discover provider.
+func (h *discoverProviderHealer) Probability() float64 {
+	// avoid division by zero.
+	if h.previousHostListSize < h.node.CountReachableMembers() {
+		h.previousHostListSize = h.node.CountReachableMembers()
+	}
+	if h.previousHostListSize < 1 {
+		h.previousHostListSize = 1
+	}
+	return h.baseProbabillity / float64(h.previousHostListSize)
+}
+
+// Heal iterates over the hostList that the discoverProvider provides. If the
+// node encounters a host that is faulty or not in the membership, we pick that
+// node as a target to perform a partition heal with.
+//
+// If heal was attempted, returns identities of the target nodes.
+func (h *discoverProviderHealer) Heal() []string {
+	h.node.emit(DiscoHealEvent{})
+	// get list from discovery provider
+	if h.node.discoverProvider == nil {
+		return []string{}
+	}
+	hostList, err := h.node.discoverProvider.Hosts()
+	if err != nil {
+		h.logger.Warn("unable to receive host list from discover provider")
+		return []string{}
+	}
+
+	h.previousHostListSize = len(hostList)
+
+	// filter hosts that we already know about and attempt to heal nodes that
+	// are complementary to the membership of this node.
+	var ret []string
+	for _, target := range hostList {
+		m, ok := h.node.memberlist.Member(target)
+		if ok && m.Status != Faulty {
+			continue
+		}
+
+		// try to heal partition
+		ret = append(ret, target)
+		err = AttemptHeal(h.node, target)
+		if err != nil {
+			h.logger.WithField("error", err.Error()).Warn("heal failed")
+		}
+		break
+	}
+	return ret
+}

--- a/swim/heal_via_discover_provider.go
+++ b/swim/heal_via_discover_provider.go
@@ -119,19 +119,22 @@ func (h *discoverProviderHealer) Heal() []string {
 	// filter hosts that we already know about and attempt to heal nodes that
 	// are complementary to the membership of this node.
 	var ret []string
-	for _, target := range hostList {
+
+	for len(hostList) != 0 {
+		target := hostList[0]
 		m, ok := h.node.memberlist.Member(target)
 		if ok && m.Status != Faulty {
+			hostList = del(hostList, target)
 			continue
 		}
 
 		// try to heal partition
-		ret = append(ret, target)
-		err = AttemptHeal(h.node, target)
+		ret = append(ret, hostList[0])
+		hostList, err = AttemptHeal(h.node, hostList)
 		if err != nil {
 			h.logger.WithField("error", err.Error()).Warn("heal failed")
 		}
-		break
 	}
+
 	return ret
 }

--- a/swim/heal_via_discover_provider.go
+++ b/swim/heal_via_discover_provider.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	log "github.com/uber-common/bark"
-	"github.com/uber/ringpop-go/discovery"
 	"github.com/uber/ringpop-go/logging"
 )
 
@@ -37,7 +36,6 @@ import (
 type discoverProviderHealer struct {
 	node *Node
 
-	discoverProvider *discovery.DiscoverProvider
 	baseProbabillity float64
 	period           time.Duration
 
@@ -112,7 +110,7 @@ func (h *discoverProviderHealer) Heal() []string {
 	}
 	hostList, err := h.node.discoverProvider.Hosts()
 	if err != nil {
-		h.logger.Warn("unable to receive host list from discover provider")
+		h.logger.Warn("healer unable to receive host list from discover provider")
 		return []string{}
 	}
 

--- a/swim/join_handler.go
+++ b/swim/join_handler.go
@@ -69,7 +69,7 @@ func handleJoin(node *Node, req *joinRequest) (*joinResponse, error) {
 	res := &joinResponse{
 		App:         node.app,
 		Coordinator: node.address,
-		Membership:  node.disseminator.FullSync(),
+		Membership:  node.disseminator.MembershipAsChanges(),
 		Checksum:    node.memberlist.Checksum(),
 	}
 

--- a/swim/member.go
+++ b/swim/member.go
@@ -136,3 +136,18 @@ func (c Change) address() string {
 func (c Change) incarnation() int64 {
 	return c.Incarnation
 }
+
+func (c Change) overrides(c2 Change) bool {
+	if c.Incarnation > c2.Incarnation {
+		return true
+	}
+	if c.Incarnation < c2.Incarnation {
+		return false
+	}
+
+	return statePrecedence(c.Status) > statePrecedence(c2.Status)
+}
+
+func (c Change) isPingable() bool {
+	return c.Status == Alive || c.Status == Suspect
+}

--- a/swim/memberlist_test.go
+++ b/swim/memberlist_test.go
@@ -72,7 +72,7 @@ func (s *MemberlistTestSuite) TestAddJoinList() {
 
 	// We add all the members of this node to the joinList because we want
 	// the joinList to contain the change for the local member.
-	mems := s.node.disseminator.FullSync()
+	mems := s.node.disseminator.MembershipAsChanges()
 	for _, mem := range mems {
 		joinList = append(joinList, mem)
 	}

--- a/swim/node_bootstrap_test.go
+++ b/swim/node_bootstrap_test.go
@@ -70,7 +70,6 @@ func (s *BootstrapTestSuite) TestBootstrapJoinsTimeOut() {
 }
 
 func (s *BootstrapTestSuite) TestBootstrapDestroy() {
-	// node := newChannelNode(s.T()).node
 	s.tnode.Destroy()
 
 	_, err := s.node.Bootstrap(&BootstrapOptions{

--- a/swim/test_utils.go
+++ b/swim/test_utils.go
@@ -157,7 +157,7 @@ func bootstrapNodes(t *testing.T, testNodes ...*testNode) []string {
 }
 
 // waitForConvergence let's the nodes gossip and returns when the nodes are converged.
-// After the cluster finished gossipping we double check that all nodes have the
+// After the cluster finished gossiping we double check that all nodes have the
 // same checksum for the memberlist, this means that the cluster is converged.
 func waitForConvergence(t *testing.T, timeout time.Duration, testNodes ...*testNode) {
 	deadline := time.Now().Add(timeout)

--- a/swim/test_utils.go
+++ b/swim/test_utils.go
@@ -158,7 +158,7 @@ func bootstrapNodes(t *testing.T, testNodes ...*testNode) []string {
 	return hostports
 }
 
-// waitForConvergence let's the nodes gossip and returns when the nodes are converged.
+// waitForConvergence lets the nodes gossip and returns when the nodes are converged.
 // After the cluster finished gossiping we double check that all nodes have the
 // same checksum for the memberlist, this means that the cluster is converged.
 func waitForConvergence(t *testing.T, timeout time.Duration, testNodes ...*testNode) {

--- a/swim/test_utils.go
+++ b/swim/test_utils.go
@@ -135,8 +135,8 @@ func genChannelNodes(t *testing.T, n int) (nodes []*testNode) {
 func memberlistHasMembers(t *testing.T, m *memberlist, members []Member) {
 	for _, expected := range members {
 		member, ok := m.Member(expected.Address)
-		require.NotNil(t, member, "member cannot be nil")
 		assert.True(t, ok, "expected member to be in memberlist")
+		require.NotNil(t, member, "member cannot be nil")
 		assert.Equal(t, expected.Status, member.Status, "expected statuses to be the same")
 	}
 }
@@ -163,6 +163,13 @@ func waitForConvergence(t *testing.T, timeout time.Duration, testNodes ...*testN
 	deadline := time.Now().Add(timeout)
 
 	nodes := testNodesToNodes(testNodes)
+
+	// 1 node is a special case because it can't drain its changes since it
+	// cannot ping or be pinged by another member
+	if len(nodes) == 1 {
+		nodes[0].disseminator.ClearChanges()
+		return
+	}
 
 Tick:
 	// return when deadline is reached

--- a/swim/test_utils.go
+++ b/swim/test_utils.go
@@ -156,15 +156,14 @@ func bootstrapNodes(t *testing.T, testNodes ...*testNode) []string {
 	return hostports
 }
 
+// waitForConvergence let's the nodes gossip and returns when the nodes are converged.
+// After the cluster finished gossipping we double check that all nodes have the
+// same checksum for the memberlist, this means that the cluster is converged.
 func waitForConvergence(t *testing.T, timeout time.Duration, testNodes ...*testNode) {
 	deadline := time.Now().Add(timeout)
 
 	nodes := testNodesToNodes(testNodes)
 
-	// To get the cluster to a converged state we will let the nodes gossip until
-	// there are no more changes. After the cluster finished gossipping we double
-	// check that all nodes have the same checksum for the memberlist, this means
-	// that the cluster is converged.
 Tick:
 	// return when deadline is reached
 	if time.Now().After(deadline) {

--- a/test/mocks/swim_node.go
+++ b/test/mocks/swim_node.go
@@ -1,6 +1,9 @@
 package mocks
 
-import "github.com/uber/ringpop-go/swim"
+import (
+	"github.com/uber/ringpop-go/events"
+	"github.com/uber/ringpop-go/swim"
+)
 import "github.com/stretchr/testify/mock"
 
 type SwimNode struct {
@@ -122,6 +125,6 @@ func (_m *SwimNode) Ready() bool {
 }
 
 // RegisterListener provides a mock function with given fields: l
-func (_m *SwimNode) RegisterListener(l swim.EventListener) {
+func (_m *SwimNode) RegisterListener(l events.EventListener) {
 	_m.Called(l)
 }

--- a/test/run-integration-tests
+++ b/test/run-integration-tests
@@ -64,8 +64,8 @@ fetch-ringpop-common() {
     fi
 
     run cd "$ringpop_common_dir"
-    #run git checkout master
-    run git pull
+    run git checkout ws-partition-healing
+    # run git pull
     run cd - >/dev/null
 
     run cd "${ringpop_common_dir}/test"

--- a/test/run-integration-tests
+++ b/test/run-integration-tests
@@ -103,7 +103,10 @@ run-test-for-cluster-size() {
     # if the test fails. This avoids interleaving of output to the terminal
     # when tests are running in parallel.
     node "${ringpop_common_dir}/test/it-tests.js" \
-        -s "[$1]" "${project_root}/testpop" &>$output_file || err=$?
+        -s "[$1]" \
+        --enable-feature bidirectional-full-syncs \
+        --enable-feature partition-healing \
+        "${project_root}/testpop" &>$output_file || err=$?
 
     if [ $PIPESTATUS -gt 0 ]; then
         echo "ERROR: Test errored for cluster size $cluster_size" | \

--- a/test/run-integration-tests
+++ b/test/run-integration-tests
@@ -60,13 +60,12 @@ prefix() {
 #
 fetch-ringpop-common() {
     if [ ! -e "$ringpop_common_dir" ]; then
-        run git clone -b ws-partition-healing --depth=1 https://github.com/uber/ringpop-common.git "$ringpop_common_dir"
+        run git clone --depth=1 https://github.com/uber/ringpop-common.git "$ringpop_common_dir"
     fi
 
     run cd "$ringpop_common_dir"
+    #run git checkout master
     run git pull
-    run git checkout ws-partition-healing
-    # run git pull
     run cd - >/dev/null
 
     run cd "${ringpop_common_dir}/test"

--- a/test/run-integration-tests
+++ b/test/run-integration-tests
@@ -60,12 +60,13 @@ prefix() {
 #
 fetch-ringpop-common() {
     if [ ! -e "$ringpop_common_dir" ]; then
-        run git clone --depth=1 https://github.com/uber/ringpop-common.git:ws-partition-healing "$ringpop_common_dir"
+        run git clone -b ws-partition-healing --depth=1 https://github.com/uber/ringpop-common.git "$ringpop_common_dir"
     fi
 
     run cd "$ringpop_common_dir"
-    run git checkout ws-partition-healing
     run git pull
+    run git checkout ws-partition-healing
+    # run git pull
     run cd - >/dev/null
 
     run cd "${ringpop_common_dir}/test"

--- a/test/run-integration-tests
+++ b/test/run-integration-tests
@@ -60,12 +60,12 @@ prefix() {
 #
 fetch-ringpop-common() {
     if [ ! -e "$ringpop_common_dir" ]; then
-        run git clone --depth=1 https://github.com/uber/ringpop-common.git "$ringpop_common_dir"
+        run git clone --depth=1 https://github.com/uber/ringpop-common.git:ws-partition-healing "$ringpop_common_dir"
     fi
 
     run cd "$ringpop_common_dir"
     run git checkout ws-partition-healing
-    # run git pull
+    run git pull
     run cd - >/dev/null
 
     run cd "${ringpop_common_dir}/test"

--- a/util/util.go
+++ b/util/util.go
@@ -184,6 +184,14 @@ func ShuffleStrings(strings []string) []string {
 	return newStrings
 }
 
+// ShuffleStrings uses the Fisher–Yates shuffle to randomize the strings in place.
+func ShuffleStringsInPlace(strings []string) {
+	for i := range strings {
+		j := rand.Intn(i + 1)
+		strings[i], strings[j] = strings[j], strings[i]
+	}
+}
+
 // TakeNode takes an element from nodes at the given index, or at a random index if
 // index < 0. Mutates nodes.
 func TakeNode(nodes *[]string, index int) string {

--- a/util/util.go
+++ b/util/util.go
@@ -184,7 +184,8 @@ func ShuffleStrings(strings []string) []string {
 	return newStrings
 }
 
-// ShuffleStrings uses the Fisher–Yates shuffle to randomize the strings in place.
+// ShuffleStringsInPlace uses the Fisher–Yates shuffle to randomize the strings
+// in place.
 func ShuffleStringsInPlace(strings []string) {
 	for i := range strings {
 		j := rand.Intn(i + 1)

--- a/util/util.go
+++ b/util/util.go
@@ -217,6 +217,15 @@ func SelectInt(opt, def int) int {
 	return opt
 }
 
+// SelectFloat takes an option and a default value and returns the default value if
+// the option is equal to zero, and the option otherwise.
+func SelectFloat(opt, def float64) float64 {
+	if opt == 0 {
+		return def
+	}
+	return opt
+}
+
 // SelectDuration takes an option and a default value and returns the default value if
 // the option is equal to zero, and the option otherwise.
 func SelectDuration(opt, def time.Duration) time.Duration {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -95,6 +95,13 @@ func TestUtilSelectOptInt(t *testing.T) {
 	assert.Equal(t, def, SelectInt(zopt, def), "expected to get default")
 }
 
+func TestUtilSelectOptFloat(t *testing.T) {
+	opt, zopt, def := 1.0, 0.0, 2.0
+
+	assert.Equal(t, opt, SelectFloat(opt, def), "expected to get option")
+	assert.Equal(t, def, SelectFloat(zopt, def), "expected to get default")
+}
+
 func TestUtilsSelectOptDuration(t *testing.T) {
 	opt, zopt, def := time.Duration(1), time.Duration(0), time.Duration(2)
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -21,6 +21,8 @@
 package util
 
 import (
+	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -238,4 +240,36 @@ func TestMin(t *testing.T) {
 
 func TestTimeZero(t *testing.T) {
 	assert.True(t, TimeZero().IsZero())
+}
+
+func TestShuffleStringsInPlace(t *testing.T) {
+	strs := make([]string, 1000)
+	strs2 := make([]string, 1000)
+	for i := range strs {
+		strs[i] = fmt.Sprint(i)
+		strs2[i] = strs[i]
+	}
+
+	ShuffleStringsInPlace(strs)
+
+	collisions := 0
+	for i := range strs {
+		if strs[i] == strs2[i] {
+			collisions++
+		}
+	}
+
+	// expected probability of 1/1000 for every index so the expected number of
+	// collisions is 1. We add some slack and expect smaller or equal than 3.
+	assert.True(t, collisions <= 3, "expected that array is shuffled")
+
+	sort.Strings(strs)
+	sort.Strings(strs2)
+	assert.Equal(t, len(strs), len(strs2), "expected size of slice did not change")
+	for i := range strs {
+		if strs[i] != strs2[i] {
+			assert.Fail(t, "expected contents of slice did not change")
+			break
+		}
+	}
 }


### PR DESCRIPTION
This PR includes an implementation of the partition healing algorithm.

When the network is partitioned and a collection of nodes A is unable to communicate with another collection of nodes B the cluster becomes in a partitioned state. A declares nodes from B faulty and B declares nodes from A faulty. If the network partition is becomes fixed, there is still no communication between A and B because faulty nodes shouldn't be pinged according to the swim protocol.

The partition healing algorithm tries to fix this state where the network is restored but the cluster is in the partitioned state described above.

A brief description of the algorithm:
- A node from A contacts a node from B and compares their memberships.
- If there are members that would cause faulty declarations when merging the two memberships according to the swim rules, the node reincarnates those members (either by declaring them suspect to its own membership, or declaring them suspect by piggybacking this over a ping to a node from B) . 
- If there are members that need to reincarnate, the node merges the partitions by applying the membership of B to it's own membership and sending its membership piggybacked over a ping to a node of B.

Please grab me to discuss, this is quite a big one.