### PR TITLE
Add 1-buffer for error channels

### DIFF
--- a/swim/join_sender.go
+++ b/swim/join_sender.go
@@ -450,7 +450,7 @@ func sendJoinRequest(node *Node, target string, timeout time.Duration) (*joinRes
 	res := &joinResponse{}
 
 	// make request
-	errC := make(chan error)
+	errC := make(chan error, 1)
 	go func() {
 		errC <- json.CallPeer(ctx, peer, node.service, "/protocol/join", req, res)
 	}()

--- a/swim/ping_request_sender.go
+++ b/swim/ping_request_sender.go
@@ -86,7 +86,7 @@ func (p *pingRequestSender) SendPingRequest() (*pingResponse, error) {
 }
 
 func (p *pingRequestSender) MakeCall(ctx json.Context, res *pingResponse) <-chan error {
-	errC := make(chan error)
+	errC := make(chan error, 1)
 
 	go func() {
 		defer close(errC)

--- a/swim/ping_sender.go
+++ b/swim/ping_sender.go
@@ -84,7 +84,7 @@ func sendPingWithChanges(node *Node, target string, changes []Change, timeout ti
 	startTime := time.Now()
 
 	// send the ping
-	errC := make(chan error)
+	errC := make(chan error, 1)
 	res := &ping{}
 	go func() {
 		errC <- json.CallPeer(ctx, peer, node.service, "/protocol/ping", req, res)


### PR DESCRIPTION
This will prevent leaking goroutines when these operations timeout:
* join
* ping
* ping_req

Related: #63