### PR TITLE
Change stat name emitted when healing

### DIFF
--- a/ringpop.go
+++ b/ringpop.go
@@ -494,7 +494,7 @@ func (rp *Ringpop) HandleEvent(event events.Event) {
 		rp.statter.IncCounter(rp.getStatKey("not-ready."+string(event.Endpoint)), nil, 1)
 
 	case swim.DiscoHealEvent:
-		rp.statter.IncCounter(rp.getStatKey("heal.triggered"), nil, 1)
+		rp.statter.IncCounter(rp.getStatKey("heal.triggered.discover_provider"), nil, 1)
 
 	case swim.AttemptHealEvent:
 		rp.statter.IncCounter(rp.getStatKey("heal.attempt"), nil, 1)

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -268,10 +268,10 @@ func (s *RingpopTestSuite) TestHandleEvents() {
 	// expected listener to record 1 event
 
 	s.ringpop.HandleEvent(swim.DiscoHealEvent{})
-	s.Equal(int64(1), stats.vals["ringpop.127_0_0_1_3001.heal.triggered"], "missing stats for received pings")
+	s.Equal(int64(1), stats.vals["ringpop.127_0_0_1_3001.heal.triggered.discover_provider"], "missing stats for heal trigger through discover provider")
 
 	s.ringpop.HandleEvent(swim.AttemptHealEvent{})
-	s.Equal(int64(1), stats.vals["ringpop.127_0_0_1_3001.heal.attempt"], "missing stats for received pings")
+	s.Equal(int64(1), stats.vals["ringpop.127_0_0_1_3001.heal.attempt"], "missing stats for heal attempt")
 
 	s.ringpop.HandleEvent(events.LookupEvent{
 		Key:      "hello",


### PR DESCRIPTION
Change stat name emitted from `heal.triggered` to `heal.triggered.discover_provider` when healing through discover provider.
Because the partition healing feature is built with multiple strategies in mind, it makes sense to continue on this path to make sure to support multiple strategies in the stat-name as well.