### PR TITLE
Fix: Race condition on hostlist reuse

### DIFF
--- a/swim/heal_via_discover_provider.go
+++ b/swim/heal_via_discover_provider.go
@@ -131,7 +131,6 @@ func (h *discoverProviderHealer) Heal() ([]string, error) {
 	}
 
 	h.previousHostListSize = len(hostList)
-	util.ShuffleStringsInPlace(hostList)
 
 	// collect the targets this node might want to heal with
 	var targets []string
@@ -141,6 +140,7 @@ func (h *discoverProviderHealer) Heal() ([]string, error) {
 			targets = append(targets, address)
 		}
 	}
+	util.ShuffleStringsInPlace(targets)
 
 	// filter hosts that we already know about and attempt to heal nodes that
 	// are complementary to the membership of this node.


### PR DESCRIPTION
There could be a case when the implementation of the `DiscoveryProvider` reuses the `hostlist` it returns that the in place shuffle would be triggered concurrently on that list.

Since the shuffled `hostlist` is only used to create a `targets` list we do not have to rely on the `hostlist` being shuffled if we shuffle the `targets` list. Since we 'own' the `targets` list we know it will not be used concurrently by an other routine.