### PR TITLE
When creating the change for reincarnation use your self as the source.

### DIFF
--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -336,11 +336,12 @@ func (m *memberlist) Update(changes []Change) (applied []Change) {
 		// if change is local override, reassert member is alive
 		if member.localOverride(m.node.Address(), change) {
 			m.node.emit(RefuteUpdateEvent{})
+			newIncNo := nowInMillis(m.node.clock)
 			overrideChange := Change{
-				Source:            change.Source,
-				SourceIncarnation: change.SourceIncarnation,
+				Source:            m.node.Address(),
+				SourceIncarnation: newIncNo,
 				Address:           change.Address,
-				Incarnation:       nowInMillis(m.node.clock),
+				Incarnation:       newIncNo,
 				Status:            Alive,
 				Timestamp:         util.Timestamp(time.Now()),
 			}

--- a/swim/memberlist_test.go
+++ b/swim/memberlist_test.go
@@ -201,9 +201,12 @@ func (s *MemberlistTestSuite) TestMultipleUpdates() {
 }
 
 func (s *MemberlistTestSuite) TestUpdateTriggersReincarnation() {
+	source := "192.0.2.1:1234"
+	s.NotEqual(source, s.m.local.Address, "this test relies on the source and the target of the change to be different")
+
 	applied := s.m.Update([]Change{
 		Change{
-			Source:            "192.0.2.1:1234",
+			Source:            source,
 			SourceIncarnation: 1337,
 
 			Address:     s.m.local.Address,

--- a/swim/memberlist_test.go
+++ b/swim/memberlist_test.go
@@ -200,6 +200,28 @@ func (s *MemberlistTestSuite) TestMultipleUpdates() {
 	s.Equal(Leave, member.Status, "expected member to be leave")
 }
 
+func (s *MemberlistTestSuite) TestUpdateTriggersReincarnation() {
+	applied := s.m.Update([]Change{
+		Change{
+			Source:            "192.0.2.1:1234",
+			SourceIncarnation: 1337,
+
+			Address:     s.m.local.Address,
+			Incarnation: s.m.local.Incarnation,
+			Status:      Suspect,
+		},
+	})
+
+	s.Len(applied, 1, "expected change to be applied")
+
+	change := applied[0]
+	s.NotNil(change, "expected change not to be nil")
+	s.Equal(Alive, change.Status, "expected change to be overwritten to alive")
+	s.Equal(s.m.local.Address, change.Source, "expected source to be the node that reincarnated its self")
+	s.Equal(s.m.local.Incarnation, change.Incarnation, "expected the new incarnation number to be the same as the one that is stored on the local node")
+	s.Equal(s.m.local.Incarnation, change.SourceIncarnation, "expected the source incarnation number to be the same as the one that is stored on the local node")
+}
+
 func (s *MemberlistTestSuite) TestAliveToFaulty() {
 	s.m.MakeAlive("127.0.0.1:3002", s.incarnation)
 


### PR DESCRIPTION
When a gossip was received that would overwrite the state of the local node we overwrite this change with a reincarnated version of our self. However we used the source of the original change as the source for this change making it harder for the reincarnated change to reach the node that declared it a suspect in the first place.

This change will use the source and new reincarnation number of the local node for this new change. This prevents the reincarnation change to be filtered out in pings to the original source causing convergence to speedup and potentially prevent fullsyncs from happening.