### PR TITLE
Emit lookup stat correctly

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -58,7 +58,7 @@ type LookupEvent struct {
 // A LookupNEvent is sent when a lookupN is performed on the Ringpop's ring
 type LookupNEvent struct {
 	Key      string
-	N 		 int
+	N        int
 	Duration time.Duration
 }
 

--- a/events/events.go
+++ b/events/events.go
@@ -55,6 +55,13 @@ type LookupEvent struct {
 	Duration time.Duration
 }
 
+// A LookupNEvent is sent when a lookupN is performed on the Ringpop's ring
+type LookupNEvent struct {
+	Key      string
+	N 		 int
+	Duration time.Duration
+}
+
 // Ready is fired when ringpop has successfully bootstrapped and is ready to receive requests and other method calls.
 type Ready struct{}
 

--- a/ringpop.go
+++ b/ringpop.go
@@ -621,7 +621,7 @@ func (rp *Ringpop) LookupN(key string, n int) ([]string, error) {
 
 	rp.emit(events.LookupNEvent{
 		Key:      key,
-		N: n,
+		N:        n,
 		Duration: duration,
 	})
 

--- a/ringpop.go
+++ b/ringpop.go
@@ -484,9 +484,6 @@ func (rp *Ringpop) HandleEvent(event events.Event) {
 	case swim.JoinTriesUpdateEvent:
 		rp.statter.UpdateGauge(rp.getStatKey("join.retries"), nil, int64(event.Retries))
 
-	case events.LookupEvent:
-		rp.statter.RecordTimer(rp.getStatKey("lookup"), nil, event.Duration)
-
 	case swim.MakeNodeStatusEvent:
 		rp.statter.IncCounter(rp.getStatKey("make-"+event.Status), nil, 1)
 
@@ -591,9 +588,12 @@ func (rp *Ringpop) Lookup(key string) (string, error) {
 
 	dest, success := rp.ring.Lookup(key)
 
+	duration := time.Now().Sub(startTime)
+	rp.statter.RecordTimer(rp.getStatKey("lookup"), nil, duration)
+
 	rp.emit(events.LookupEvent{
 		Key:      key,
-		Duration: time.Now().Sub(startTime),
+		Duration: duration,
 	})
 
 	if !success {

--- a/ringpop.go
+++ b/ringpop.go
@@ -619,6 +619,12 @@ func (rp *Ringpop) LookupN(key string, n int) ([]string, error) {
 	duration := time.Now().Sub(startTime)
 	rp.statter.RecordTimer(rp.getStatKey(fmt.Sprintf("lookupn.%d", n)), nil, duration)
 
+	rp.emit(events.LookupNEvent{
+		Key:      key,
+		N: n,
+		Duration: duration,
+	})
+
 	if len(destinations) == 0 {
 		err := errors.New("could not find destinations for key")
 		rp.logger.WithField("key", key).Warn(err)

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -542,6 +542,17 @@ func (s *RingpopTestSuite) TestLookupNotReady() {
 	s.Empty(result)
 }
 
+func (s *RingpopTestSuite) TestLookupNoDestination() {
+	createSingleNodeCluster(s.ringpop)
+
+	address,_ := s.ringpop.identity()
+	s.ringpop.ring.RemoveServer(address)
+
+	result, err := s.ringpop.Lookup("foo")
+	s.Equal("", result)
+	s.Error(err)
+}
+
 func (s *RingpopTestSuite) TestLookupEmitStat() {
 	createSingleNodeCluster(s.ringpop)
 
@@ -575,6 +586,33 @@ func (s *RingpopTestSuite) TestLookupNNotReady() {
 	result, err := s.ringpop.LookupN("foo", 3)
 	s.Error(err)
 	s.Nil(result)
+}
+
+func (s *RingpopTestSuite) TestLookupNNoDestinations() {
+	createSingleNodeCluster(s.ringpop)
+
+	address, _ := s.ringpop.identity()
+	s.ringpop.ring.RemoveServer(address)
+
+	result, err := s.ringpop.LookupN("foo", 5)
+	s.Nil(result)
+	s.Error(err)
+}
+
+func (s *RingpopTestSuite) TestLookupN() {
+	createSingleNodeCluster(s.ringpop)
+
+	result, err := s.ringpop.LookupN("foo", 5)
+
+	s.Nil(err)
+	s.Equal(1, len(result), "LookupN returns not more results then number of nodes")
+
+	addresses := genAddresses(1, 10, 20)
+	s.ringpop.ring.AddRemoveServers(addresses, nil)
+
+	result, err = s.ringpop.LookupN("foo", 5)
+	s.Nil(err)
+	s.Equal(5, len(result), "LookupN returns N number of results")
 }
 
 // TestGetReachableMembersNotReady tests that GetReachableMembers fails when

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/uber/ringpop-go/swim"
 	"github.com/uber/ringpop-go/test/mocks"
 	"github.com/uber/tchannel-go"
-	"fmt"
 )
 
 type destroyable interface {
@@ -550,7 +549,7 @@ func (s *RingpopTestSuite) TestLookupEmitStat() {
 	s.ringpop.statter = stats
 
 	_, _ = s.ringpop.Lookup("foo")
-	
+
 	_, ok := stats.vals["ringpop.127_0_0_1_3001.lookup"]
 	s.True(ok, "missing lookup timer")
 }

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -605,7 +605,7 @@ func (s *RingpopTestSuite) TestLookupN() {
 	result, err := s.ringpop.LookupN("foo", 5)
 
 	s.Nil(err)
-	s.Equal(1, len(result), "LookupN returns not more results then number of nodes")
+	s.Equal(1, len(result), "LookupN returns not more results than number of nodes")
 
 	addresses := genAddresses(1, 10, 20)
 	s.ringpop.ring.AddRemoveServers(addresses, nil)

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -554,6 +554,22 @@ func (s *RingpopTestSuite) TestLookupEmitStat() {
 	s.True(ok, "missing lookup timer")
 }
 
+func (s *RingpopTestSuite) TestLookupNEmitStat() {
+	createSingleNodeCluster(s.ringpop)
+
+	stats := newDummyStats()
+	s.ringpop.statter = stats
+
+	_, _ = s.ringpop.LookupN("foo", 3)
+	_, _ = s.ringpop.LookupN("foo", 5)
+
+	_, ok := stats.vals["ringpop.127_0_0_1_3001.lookupn.3"]
+	s.True(ok, "missing lookupn.3 timer")
+
+	_, ok = stats.vals["ringpop.127_0_0_1_3001.lookupn.5"]
+	s.True(ok, "missing lookupn.5 timer")
+}
+
 // TestLookupNNotReady tests that LookupN fails when Ringpop is not ready.
 func (s *RingpopTestSuite) TestLookupNNotReady() {
 	result, err := s.ringpop.LookupN("foo", 3)

--- a/ringpop_test.go
+++ b/ringpop_test.go
@@ -545,7 +545,7 @@ func (s *RingpopTestSuite) TestLookupNotReady() {
 func (s *RingpopTestSuite) TestLookupNoDestination() {
 	createSingleNodeCluster(s.ringpop)
 
-	address,_ := s.ringpop.identity()
+	address, _ := s.ringpop.identity()
 	s.ringpop.ring.RemoveServer(address)
 
 	result, err := s.ringpop.Lookup("foo")


### PR DESCRIPTION
Previously the lookup stat was emitted from the event-handler inside of `ringpop.go` when a `LookupEvent` was emitted. However, the lookup-event is emitted on ringpop itself so it's internal event-handler isn't triggered.