### PR TITLE
Test examples/ping-*/README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ hosts.json
 coverage.out
 lint.log
 /vendor/
+/_venv/
+README.md.err
+tick-cluster.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ go:
   - 1.6
   - 1.5
 
+sudo: false
+addons:
+  apt:
+    packages:
+    - python-virtualenv
+
 install:
   - go get -u github.com/Masterminds/glide
   - go get github.com/axw/gocov/gocov
@@ -11,6 +17,8 @@ install:
   - go get github.com/golang/lint/golint
   - ./scripts/travis/get-thrift.sh
   - ./scripts/travis/get-thrift-gen.sh
+  - ./scripts/travis/get-cram.sh
+  - npm install -g tcurl
   - make setup
 
 env:
@@ -18,6 +26,7 @@ env:
   - RUN="make test-unit"
   - RUN="make test-integration"
   - RUN="make test-race"
+  - RUN="make test-examples"
 
 matrix:
   allow_failures:
@@ -33,3 +42,4 @@ after_success:
 cache:
   directories:
     - $HOME/.glide/cache
+    - _venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ go:
   - 1.6
   - 1.5
 
-sudo: false
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ env:
 matrix:
   allow_failures:
     - env: RUN="make test-race"
+    - env: RUN="make test-examples"
+
   fast_finish: true
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -59,19 +59,22 @@ setup: dev_deps
 
 test:	test-unit test-integration
 
-test-integration:
+test-integration: vendor
 	test/run-integration-tests
 
 test-unit:
 	go generate $(NOVENDOR)
 	test/go-test-prettify $(NOVENDOR)
 
-test-examples: _venv/bin/cram vendor
+test-examples: vendor _venv/bin/cram
 	. _venv/bin/activate && ./test/run-example-tests
 
-test-race:
+test-race: vendor
 	go generate $(NOVENDOR)
 	test/go-test-prettify -race $(NOVENDOR)
+
+vendor:
+	$(error run 'make setup' first)
 
 _venv/bin/cram:
 	./scripts/travis/get-cram.sh

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,15 @@ test-unit:
 	go generate $(NOVENDOR)
 	test/go-test-prettify $(NOVENDOR)
 
+test-examples: _venv/bin/cram vendor
+	. _venv/bin/activate && ./test/run-example-tests
+
 test-race:
 	go generate $(NOVENDOR)
 	test/go-test-prettify -race $(NOVENDOR)
+
+_venv/bin/cram:
+	./scripts/travis/get-cram.sh
 
 testpop:	clean
 	go build ./scripts/testpop/

--- a/examples/ping-json/README.md
+++ b/examples/ping-json/README.md
@@ -3,37 +3,31 @@ A simple ping-pong service implementation that that integrates ringpop to forwar
 # Running the example
 
 All commands are relative to this directory:
-```bash
-cd examples/ping-json
-```
 
-Build the example binary:
-```bash
-go build
-```
+  $ cd ${TESTDIR}  # examples/ping-json
+  $ go build
 
 Start a custer of 5 nodes using [tick-cluster][1]:
-```bash
-tick-cluster.js -n 5 ping-json
-```
+
+  $ tick-cluster.js --interface=127.0.0.1 -n 5 ping-json &> tick-cluster.log &
+  $ sleep 5
 
 Lookup the node `my_key` key belongs to using [tcurl][2]:
-```bash
-$ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
-{"ok":true,"head":null,"body":{"dest":"127.0.0.1:3002"},"headers":{"as":"json"},"trace":"88c8217f8ce220fd"}
-```
+
+  $ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
+  {"ok":true,"head":null,"body":{"dest":"127.0.0.1:300?"},"headers":{"as":"json"},"trace":"*"} (glob)
 
 Call the `/ping` endpoint (multiple times) and see the request being forwarded. Each request is sent to a random node in the cluster because of the `-P hosts.json` argument--but is always handled by the node owning the key. This can be seen in the `from` field of the response:
-```bash
-$ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}'
-{"ok":true,"head":null,"body":{"message":"Hello, world!","from":"127.0.0.1:3002","p":""},"headers":{"as":"json"},"trace":"825d0c582c758aa5"}
-```
+
+  $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}'
+  {"ok":true,"head":null,"body":{"message":"Hello, world!","from":"127.0.0.1:300?","p":""},"headers":{"as":"json"},"trace":"*"} (glob)
 
 Optionally, set the `p` header. This value will be forwarded together with the request body to the node owning the key. Its value is returned in the response body in the `pheader` field:
-```bash
-$ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
-{"ok":true,"head":null,"body":{"message":"Hello, world!","from":"127.0.0.1:3002","pheader":"my_header"},"headers":{"as":"json"},"trace":"36b2a16b57b92945"}
-```
+
+  $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
+  {"ok":true,"head":null,"body":{"message":"Hello, world!","from":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"json"},"trace":"*"} (glob)
+
+  $ kill %1
 
 [1]:https://github.com/uber/ringpop-common/
 [2]:https://github.com/uber/tcurl

--- a/examples/ping-json/README.md
+++ b/examples/ping-json/README.md
@@ -4,30 +4,30 @@ A simple ping-pong service implementation that that integrates ringpop to forwar
 
 All commands are relative to this directory:
 
-  $ cd ${TESTDIR}  # examples/ping-json
-  $ go build
+    $ cd ${TESTDIR}  # examples/ping-json
+    $ go build
 
 Start a custer of 5 nodes using [tick-cluster][1]:
 
-  $ tick-cluster.js --interface=127.0.0.1 -n 5 ping-json &> tick-cluster.log &
-  $ sleep 5
+    $ tick-cluster.js --interface=127.0.0.1 -n 5 ping-json &> tick-cluster.log &
+    $ sleep 5
 
 Lookup the node `my_key` key belongs to using [tcurl][2]:
 
-  $ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
-  {"ok":true,"head":null,"body":{"dest":"127.0.0.1:300?"},"headers":{"as":"json"},"trace":"*"} (glob)
+    $ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
+    {"ok":true,"head":null,"body":{"dest":"127.0.0.1:300?"},"headers":{"as":"json"},"trace":"*"} (glob)
 
 Call the `/ping` endpoint (multiple times) and see the request being forwarded. Each request is sent to a random node in the cluster because of the `-P hosts.json` argument--but is always handled by the node owning the key. This can be seen in the `from` field of the response:
 
-  $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}'
-  {"ok":true,"head":null,"body":{"message":"Hello, world!","from":"127.0.0.1:300?","p":""},"headers":{"as":"json"},"trace":"*"} (glob)
+    $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}'
+    {"ok":true,"head":null,"body":{"message":"Hello, world!","from":"127.0.0.1:300?","p":""},"headers":{"as":"json"},"trace":"*"} (glob)
 
 Optionally, set the `p` header. This value will be forwarded together with the request body to the node owning the key. Its value is returned in the response body in the `pheader` field:
 
-  $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
-  {"ok":true,"head":null,"body":{"message":"Hello, world!","from":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"json"},"trace":"*"} (glob)
+    $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
+    {"ok":true,"head":null,"body":{"message":"Hello, world!","from":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"json"},"trace":"*"} (glob)
 
-  $ kill %1
+    $ kill %1
 
 [1]:https://github.com/uber/ringpop-common/
 [2]:https://github.com/uber/tcurl

--- a/examples/ping-json/README.md
+++ b/examples/ping-json/README.md
@@ -1,5 +1,7 @@
 A simple ping-pong service implementation that that integrates ringpop to forward requests between nodes.
 
+Note: this file can be [cram][3]-executed using `make test-examples`. That's why some of the example outputs below are a bit unusual.
+
 # Running the example
 
 All commands are relative to this directory:
@@ -31,3 +33,4 @@ Optionally, set the `p` header. This value will be forwarded together with the r
 
 [1]:https://github.com/uber/ringpop-common/
 [2]:https://github.com/uber/tcurl
+[3]:https://pypi.python.org/pypi/cram

--- a/examples/ping-thrift-gen/README.md
+++ b/examples/ping-thrift-gen/README.md
@@ -5,42 +5,38 @@ This example it's different than the others because it uses ringpop specific gen
 # Running the example
 
 All commands are relative to this directory:
-```bash
-cd examples/ping-thrift-gen
-```
+
+  $ cd ${TESTDIR}  # examples/ping-thrift-gen
 
 (optional, the files are already included) Generate the thrift code:
-```bash
-thrift-gen --generateThrift --outputDir gen-go --inputFile ping.thrift --template github.com/uber/ringpop-go/ringpop.thrift-gen
-```
+
+  $ thrift-gen --generateThrift --outputDir gen-go --inputFile ping.thrift --template github.com/uber/ringpop-go/ringpop.thrift-gen
 
 Build the example binary:
-```bash
-go build
-```
+
+  $ go build
 
 Start a custer of 5 nodes using [tick-cluster][1]:
-```bash
-tick-cluster.js -n 5 ping-thrift-gen
-```
+
+  $ tick-cluster.js --interface=127.0.0.1 -n 5 ping-thrift-gen &> tick-cluster.log &
+  $ sleep 5
 
 Lookup the node `my_key` key belongs to using [tcurl][2]:
-```bash
-$ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
-{"ok":true,"head":null,"body":{"dest":"127.0.0.1:3002"},"headers":{"as":"json"},"trace":"7a612e506428cec2"}
-```
+
+  $ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
+  {"ok":true,"head":null,"body":{"dest":"127.0.0.1:300?"},"headers":{"as":"json"},"trace":"*"} (glob)
 
 Call the `PingPongService::Ping` endpoint (multiple times) and see the request being forwarded. Each request is sent to a random node in the cluster because of the `-P hosts.json` argument--but is always handled by the node owning the key. This can be seen in the `from` field of the response:
-```bash
-$ tcurl pingchannel -P hosts.json --thrift ./ping.thrift PingPongService::Ping '{"request": {"key": "my_key"}}'
-{"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:3002","pheader":""},"headers":{"as":"thrift"},"trace":"650cbf0656e215e2"}
-```
+
+  $ tcurl pingchannel -P hosts.json --thrift ./ping.thrift PingPongService::Ping '{"request": {"key": "my_key"}}'
+  {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":""},"headers":{"as":"thrift"},"trace":"*"} (glob)
 
 Optionally, set the `p` header. This value will be forwarded together with the request body to the node owning the key. Its value is returned in the response body in the `pheader` field:
-```bash
-$ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
-{"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:3002","pheader":"my_header"},"headers":{"as":"thrift"},"trace":"b5526f9625a88347"}
-```
+
+  $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
+  {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"thrift"},"trace":"*"} (glob)
+
+  $ kill %1
 
 [1]:https://github.com/uber/ringpop-common/
 [2]:https://github.com/uber/tcurl

--- a/examples/ping-thrift-gen/README.md
+++ b/examples/ping-thrift-gen/README.md
@@ -6,37 +6,37 @@ This example it's different than the others because it uses ringpop specific gen
 
 All commands are relative to this directory:
 
-  $ cd ${TESTDIR}  # examples/ping-thrift-gen
+    $ cd ${TESTDIR}  # examples/ping-thrift-gen
 
 (optional, the files are already included) Generate the thrift code:
 
-  $ thrift-gen --generateThrift --outputDir gen-go --inputFile ping.thrift --template github.com/uber/ringpop-go/ringpop.thrift-gen
+    $ thrift-gen --generateThrift --outputDir gen-go --inputFile ping.thrift --template github.com/uber/ringpop-go/ringpop.thrift-gen
 
 Build the example binary:
 
-  $ go build
+    $ go build
 
 Start a custer of 5 nodes using [tick-cluster][1]:
 
-  $ tick-cluster.js --interface=127.0.0.1 -n 5 ping-thrift-gen &> tick-cluster.log &
-  $ sleep 5
+    $ tick-cluster.js --interface=127.0.0.1 -n 5 ping-thrift-gen &> tick-cluster.log &
+    $ sleep 5
 
 Lookup the node `my_key` key belongs to using [tcurl][2]:
 
-  $ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
-  {"ok":true,"head":null,"body":{"dest":"127.0.0.1:300?"},"headers":{"as":"json"},"trace":"*"} (glob)
+    $ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
+    {"ok":true,"head":null,"body":{"dest":"127.0.0.1:300?"},"headers":{"as":"json"},"trace":"*"} (glob)
 
 Call the `PingPongService::Ping` endpoint (multiple times) and see the request being forwarded. Each request is sent to a random node in the cluster because of the `-P hosts.json` argument--but is always handled by the node owning the key. This can be seen in the `from` field of the response:
 
-  $ tcurl pingchannel -P hosts.json --thrift ./ping.thrift PingPongService::Ping '{"request": {"key": "my_key"}}'
-  {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":""},"headers":{"as":"thrift"},"trace":"*"} (glob)
+    $ tcurl pingchannel -P hosts.json --thrift ./ping.thrift PingPongService::Ping '{"request": {"key": "my_key"}}'
+    {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":""},"headers":{"as":"thrift"},"trace":"*"} (glob)
 
 Optionally, set the `p` header. This value will be forwarded together with the request body to the node owning the key. Its value is returned in the response body in the `pheader` field:
 
-  $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
-  {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"thrift"},"trace":"*"} (glob)
+    $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
+    {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"thrift"},"trace":"*"} (glob)
 
-  $ kill %1
+    $ kill %1
 
 [1]:https://github.com/uber/ringpop-common/
 [2]:https://github.com/uber/tcurl

--- a/examples/ping-thrift-gen/README.md
+++ b/examples/ping-thrift-gen/README.md
@@ -1,5 +1,7 @@
 A simple ping-pong service implementation that that integrates ringpop to forward requests between nodes.
 
+Note: this file can be [cram][3]-executed using `make test-examples`. That's why some of the example outputs below are a bit unusual.
+
 This example it's different than the others because it uses ringpop specific generated code to avoid some of the boilerplate.
 
 # Running the example
@@ -40,3 +42,4 @@ Optionally, set the `p` header. This value will be forwarded together with the r
 
 [1]:https://github.com/uber/ringpop-common/
 [2]:https://github.com/uber/tcurl
+[3]:https://pypi.python.org/pypi/cram

--- a/examples/ping-thrift/README.md
+++ b/examples/ping-thrift/README.md
@@ -4,38 +4,38 @@ A simple ping-pong service implementation that that integrates ringpop to forwar
 
 All commands are relative to this directory:
 
-  $ cd ${TESTDIR}  # examples/ping-thrift
+    $ cd ${TESTDIR}  # examples/ping-thrift
 
 (optional, the files are already included) Generate the thrift code:
 
-  $ thrift-gen --generateThrift --outputDir gen-go --inputFile ping.thrift
+    $ thrift-gen --generateThrift --outputDir gen-go --inputFile ping.thrift
 
 Build the example binary:
 
-  $ go build
+    $ go build
 
 
 Start a custer of 5 nodes using [tick-cluster][1]:
 
-  $ tick-cluster.js --interface=127.0.0.1 -n 5 ping-thrift &> tick-cluster.log &
-  $ sleep 5
+    $ tick-cluster.js --interface=127.0.0.1 -n 5 ping-thrift &> tick-cluster.log &
+    $ sleep 5
 
 Lookup the node `my_key` key belongs to using [tcurl][2]:
 
-  $ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
-  {"ok":true,"head":null,"body":{"dest":"127.0.0.1:300?"},"headers":{"as":"json"},"trace":"*"} (glob)
+    $ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
+    {"ok":true,"head":null,"body":{"dest":"127.0.0.1:300?"},"headers":{"as":"json"},"trace":"*"} (glob)
 
 Call the `PingPongService::Ping` endpoint (multiple times) and see the request being forwarded. Each request is sent to a random node in the cluster because of the `-P hosts.json` argument--but is always handled by the node owning the key. This can be seen in the `from` field of the response:
 
-  $ tcurl pingchannel -P hosts.json --thrift ./ping.thrift PingPongService::Ping '{"request": {"key": "my_key"}}'
-  {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":""},"headers":{"as":"thrift"},"trace":"*"} (glob)
+    $ tcurl pingchannel -P hosts.json --thrift ./ping.thrift PingPongService::Ping '{"request": {"key": "my_key"}}'
+    {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":""},"headers":{"as":"thrift"},"trace":"*"} (glob)
 
 Optionally, set the `p` header. This value will be forwarded together with the request body to the node owning the key. Its value is returned in the response body in the `pheader` field:
 
-  $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
-  {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"thrift"},"trace":"*"} (glob)
+    $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
+    {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"thrift"},"trace":"*"} (glob)
 
-  $ kill %1
+    $ kill %1
 
 [1]:https://github.com/uber/ringpop-common/
 [2]:https://github.com/uber/tcurl

--- a/examples/ping-thrift/README.md
+++ b/examples/ping-thrift/README.md
@@ -3,42 +3,39 @@ A simple ping-pong service implementation that that integrates ringpop to forwar
 # Running the example
 
 All commands are relative to this directory:
-```bash
-cd examples/ping-thrift
-```
+
+  $ cd ${TESTDIR}  # examples/ping-thrift
 
 (optional, the files are already included) Generate the thrift code:
-```bash
-thrift-gen --generateThrift --outputDir gen-go --inputFile ping.thrift
-```
+
+  $ thrift-gen --generateThrift --outputDir gen-go --inputFile ping.thrift
 
 Build the example binary:
-```bash
-go build
-```
+
+  $ go build
+
 
 Start a custer of 5 nodes using [tick-cluster][1]:
-```bash
-tick-cluster.js -n 5 ping-thrift
-```
+
+  $ tick-cluster.js --interface=127.0.0.1 -n 5 ping-thrift &> tick-cluster.log &
+  $ sleep 5
 
 Lookup the node `my_key` key belongs to using [tcurl][2]:
-```bash
-$ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
-{"ok":true,"head":null,"body":{"dest":"127.0.0.1:3002"},"headers":{"as":"json"},"trace":"7a612e506428cec2"}
-```
+
+  $ tcurl ringpop -P hosts.json /admin/lookup '{"key": "my_key"}'
+  {"ok":true,"head":null,"body":{"dest":"127.0.0.1:300?"},"headers":{"as":"json"},"trace":"*"} (glob)
 
 Call the `PingPongService::Ping` endpoint (multiple times) and see the request being forwarded. Each request is sent to a random node in the cluster because of the `-P hosts.json` argument--but is always handled by the node owning the key. This can be seen in the `from` field of the response:
-```bash
-$ tcurl pingchannel -P hosts.json --thrift ./ping.thrift PingPongService::Ping '{"request": {"key": "my_key"}}'
-{"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:3002","pheader":""},"headers":{"as":"thrift"},"trace":"650cbf0656e215e2"}
-```
+
+  $ tcurl pingchannel -P hosts.json --thrift ./ping.thrift PingPongService::Ping '{"request": {"key": "my_key"}}'
+  {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":""},"headers":{"as":"thrift"},"trace":"*"} (glob)
 
 Optionally, set the `p` header. This value will be forwarded together with the request body to the node owning the key. Its value is returned in the response body in the `pheader` field:
-```bash
-$ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
-{"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:3002","pheader":"my_header"},"headers":{"as":"thrift"},"trace":"b5526f9625a88347"}
-```
+
+  $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
+  {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"thrift"},"trace":"*"} (glob)
+
+  $ kill %1
 
 [1]:https://github.com/uber/ringpop-common/
 [2]:https://github.com/uber/tcurl

--- a/examples/ping-thrift/README.md
+++ b/examples/ping-thrift/README.md
@@ -1,5 +1,7 @@
 A simple ping-pong service implementation that that integrates ringpop to forward requests between nodes.
 
+Note: this file can be [cram][3]-executed using `make test-examples`. That's why some of the example outputs below are a bit unusual.
+
 # Running the example
 
 All commands are relative to this directory:
@@ -39,3 +41,4 @@ Optionally, set the `p` header. This value will be forwarded together with the r
 
 [1]:https://github.com/uber/ringpop-common/
 [2]:https://github.com/uber/tcurl
+[3]:https://pypi.python.org/pypi/cram

--- a/scripts/travis/get-cram.sh
+++ b/scripts/travis/get-cram.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+if [[ ! -f "_venv/bin/activate" ]]; then
+    virtualenv _venv
+fi
+
+. _venv/bin/activate
+
+if [[ -z "$(which cram)" ]]; then
+    ./_venv/bin/pip install cram
+fi

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -6,6 +6,7 @@ declare ringpop_common_branch="master"
 
 #
 # Clones or updates the ringpop-common repository.
+# Runs `npm install` in ringpop-common/$1.
 #
 fetch-ringpop-common() {
     if [ ! -e "$ringpop_common_dir" ]; then

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -1,0 +1,47 @@
+# Common functions for test code
+
+declare project_root="${0%/*}/.."
+declare ringpop_common_dir="${0%/*}/ringpop-common"
+declare ringpop_common_branch="master"
+
+#
+# Clones or updates the ringpop-common repository.
+#
+fetch-ringpop-common() {
+    if [ ! -e "$ringpop_common_dir" ]; then
+        run git clone --depth=1 https://github.com/uber/ringpop-common.git "$ringpop_common_dir" --branch "$ringpop_common_branch"
+    fi
+
+    run cd "$ringpop_common_dir"
+    #run git checkout latest version of $ringpop_common_branch
+    run git fetch origin "$ringpop_common_branch"
+    run git checkout "FETCH_HEAD"
+
+    run cd - >/dev/null
+
+    run cd "${ringpop_common_dir}/$1"
+    if [[ ! -d "node_modules" && ! -d "../node_modules" ]]; then
+        run npm install #>/dev/null
+    fi
+    run cd - >/dev/null
+}
+
+#
+# Copy stdin to stdout but prefix each line with the specified string.
+#
+prefix() {
+    local _prefix=
+
+    [ -n "$1" ] && _prefix="[$1] "
+    while IFS= read -r -t 30 line; do
+        echo "${_prefix}${line}"
+    done
+}
+
+#
+# Echos and runs the specified command.
+#
+run() {
+    echo "+ $@" >&2
+    "$@"
+}

--- a/test/run-example-tests
+++ b/test/run-example-tests
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# Runs the ringpop-admin tests.
+#
+# This script launches a ringpop cluster using tick-cluster and then runs
+# a series of tests against the ringpop-admin command output.
+#
+set -euo pipefail
+
+
+declare cram_opts="-v --shell=/bin/bash"
+declare prog_cram="cram"
+declare test_files="${0%/*}/../examples/*/README.md"
+
+# Import common functions
+. "${0%/*}/lib.sh"
+
+#
+# Print the specified text to stdout, prefixing with a timestamp.
+#
+# $1: Text to print
+#
+_print() {
+    echo -e "[$(date)] ${0##*/}: $@"
+}
+
+#
+# Echos the full normalised path of the specified path, or nothing if the path
+# does not exist.
+#
+_normalise_path() {
+    path="$(cd "$1" && echo $PWD)"
+    if [ $? -gt 0 ]; then
+        return 1
+    else
+        echo $path
+        return 0
+    fi
+}
+
+if [ $# -gt 0 ]; then
+
+    if [ "$1" == "--help" -o "$1" == "-h" ]; then
+        {
+            echo
+            echo "Run the tests for ringpop-go/examples."
+            echo
+            echo "Usage: $0 [--update] [test_file] [...]"
+            echo
+            echo "  --update      When a test fails, prompt to update the saved test output."
+            echo
+        } >&2
+        exit 1
+    fi
+
+    if [ "$1" == "--update" ]; then
+        cram_opts="$cram_opts -i"
+        shift
+    fi
+
+fi
+
+# Check cram is installed
+if ! type cram &>/dev/null; then
+    echo "$0 requires cram to be installed (try: 'sudo pip install cram')." >&2
+    echo
+    exit 1
+fi
+
+fetch-ringpop-common "tools" 2>&1
+
+export PATH=$PATH:$(_normalise_path "${ringpop_common_dir}/tools")
+
+run_test() {
+	# Check test files exist
+	if ! ls "$@" >/dev/null; then
+		echo "ERROR: Test files missing." >&2
+		exit 1
+	fi
+
+	# Run the tests
+	_print "Running tests..."
+    exit_code=0
+	cram $cram_opts "$@" || exit_code=1
+
+	return $exit_code
+}
+
+declare test_result=0
+# Accept test files as arguments
+if [ $# -gt 0 ]; then
+    run_test "$@" || test_result=1
+else
+	_print "Testing $test_files"
+	run_test $test_files
+fi
+
+
+if [ $test_result -eq 0 ]; then
+    _print "\033[0;32mSuccess!\033[0m"
+fi
+
+_print "exiting $test_result"
+
+exit $test_result

--- a/test/run-example-tests
+++ b/test/run-example-tests
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 
-declare cram_opts="-v --shell=/bin/bash"
+declare cram_opts="-v --shell=/bin/bash --indent=4"
 declare prog_cram="cram"
 declare test_files="${0%/*}/../examples/*/README.md"
 

--- a/test/run-integration-tests
+++ b/test/run-integration-tests
@@ -4,9 +4,9 @@
 #
 set -eo pipefail
 
-declare project_root="${0%/*}/.."
-declare ringpop_common_dir="${0%/*}/ringpop-common"
-declare ringpop_common_branch="master"
+# Import common functions and variables
+. "${0%/*}/lib.sh"
+
 declare tap_filter="${ringpop_common_dir}/test/tap-filter"
 
 declare test_cluster_sizes="1 2 3 4 5 10"
@@ -44,46 +44,6 @@ run() {
     "$@"
 }
 
-#
-# Copy stdin to stdout but prefix each line with the specified string.
-#
-prefix() {
-    local _prefix=
-
-    [ -n "$1" ] && _prefix="[$1] "
-    while IFS= read -r -t 30 line; do
-        echo "${_prefix}${line}"
-    done
-}
-
-#
-# Clones or updates the ringpop-common repository.
-#
-fetch-ringpop-common() {
-    if [ ! -e "$ringpop_common_dir" ]; then
-        run git clone --depth=1 https://github.com/uber/ringpop-common.git "$ringpop_common_dir" --branch "$ringpop_common_branch"
-    fi
-
-    run cd "$ringpop_common_dir"
-    #run git checkout latest version of $ringpop_common_branch
-    run git fetch origin "$ringpop_common_branch"
-    run git checkout "FETCH_HEAD"
-
-    run cd - >/dev/null
-
-    run cd "${ringpop_common_dir}/test"
-    run npm install >/dev/null
-    run cd - >/dev/null
-
-    # Check tap-filter exists in ringpop-common. It is required to filter output
-    # correctly to stdout/stderr
-    if ! [ -x "$tap_filter" ]; then
-        echo "ERROR: missing '$tap_filter' in ringpop-common" >&2
-        exit 1
-    fi
-}
-
-#
 # Build the testpop binary.
 #
 build-testpop() {
@@ -167,7 +127,7 @@ run-tests-serial() {
 }
 
 # Fetch and build in parallel
-{ fetch-ringpop-common 2>&1|prefix "fetch ringpop-common"; } &
+{ fetch-ringpop-common "test" 2>&1|prefix "fetch ringpop-common"; } &
 { build-testpop 2>&1|prefix "build testpop"; } &
 wait-all
 


### PR DESCRIPTION
Using [cram][1] to execute and verify instructions in the following files:

* `examples/ping-json/README.md`
* `examples/ping-thrift-gen/README.md`
* `examples/ping-thrift/README.md`

Currently, all of the tests are failing due to incomplete instructions in the README, but opening the pull  request anyway to set the path forward to fixing them.

[1]: https://pypi.python.org/pypi/cram