### PR TITLE
Improve cache by not storing ORIG_HEAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,6 @@ after_success:
 cache:
   directories:
     - $HOME/.glide/cache
+
+before_cache:
+  - find $HOME/.glide/cache -name ORIG_HEAD -exec rm {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ cache:
   directories:
     - $HOME/.glide/cache
 
-before_cache:
+before_cache:  # glide touches ORIG_HEAD on `glide install`
   - find $HOME/.glide/cache -name ORIG_HEAD -exec rm {} \;


### PR DESCRIPTION
`glide install` step touches `ORIG_HEAD` of some dependencies, causing it to update the whole cache on every run. If we remove it, the cache will not need to be updated after every execution, speeding all tests.

Tests here:
- https://travis-ci.org/uber/ringpop-go/jobs/141601533 (initial run, filling cache)
- https://travis-ci.org/uber/ringpop-go/jobs/141608840 (subsequent run)

At the end of the second run, observe "store build cache.. nothing changed, not updating cache".