### PR TITLE
Status refactor 1: Refactor membership to use localMember as the source of truth

### DIFF
--- a/swim/disseminator.go
+++ b/swim/disseminator.go
@@ -108,13 +108,10 @@ func (d *disseminator) MembershipAsChanges() (changes []Change) {
 	d.Lock()
 
 	for _, member := range d.node.memberlist.GetMembers() {
-		changes = append(changes, Change{
-			Address:           member.Address,
-			Incarnation:       member.Incarnation,
-			Source:            d.node.Address(),
-			SourceIncarnation: d.node.Incarnation(),
-			Status:            member.Status,
-		}.validateOutgoing())
+		change := Change{}
+		change.populateSubject(&member)
+		change.populateSource(d.node.memberlist.local)
+		changes = append(changes, change.validateOutgoing())
 	}
 
 	d.Unlock()

--- a/swim/gossip_test.go
+++ b/swim/gossip_test.go
@@ -88,10 +88,12 @@ func (s *GossipTestSuite) TestUpdatesArePropagated() {
 	s.node.disseminator.ClearChanges()
 	peer.node.disseminator.ClearChanges()
 
-	peer.node.memberlist.MakeAlive("127.0.0.1:3003", s.incarnation)
-	peer.node.memberlist.MakeFaulty("127.0.0.1:3004", s.incarnation)
-	peer.node.memberlist.MakeSuspect("127.0.0.1:3005", s.incarnation)
-	peer.node.memberlist.MakeLeave("127.0.0.1:3006", s.incarnation)
+	peer.node.memberlist.Update([]Change{
+		Change{Address: "127.0.0.1:3003", Incarnation: s.incarnation, Status: Alive},
+		Change{Address: "127.0.0.1:3004", Incarnation: s.incarnation, Status: Faulty},
+		Change{Address: "127.0.0.1:3005", Incarnation: s.incarnation, Status: Suspect},
+		Change{Address: "127.0.0.1:3006", Incarnation: s.incarnation, Status: Leave},
+	})
 
 	s.Len(peer.node.disseminator.changes, 4)
 

--- a/swim/handlers.go
+++ b/swim/handlers.go
@@ -138,12 +138,12 @@ func (n *Node) tickHandler(ctx json.Context, req *emptyArg) (*ping, error) {
 }
 
 func (n *Node) adminJoinHandler(ctx json.Context, req *emptyArg) (*Status, error) {
-	n.memberlist.Reincarnate()
+	n.memberlist.SetLocalStatus(Alive)
 	return &Status{Status: "rejoined"}, nil
 }
 
 func (n *Node) adminLeaveHandler(ctx json.Context, req *emptyArg) (*Status, error) {
-	n.memberlist.MakeLeave(n.address, n.memberlist.local.incarnation())
+	n.memberlist.SetLocalStatus(Leave)
 	return &Status{Status: "ok"}, nil
 }
 

--- a/swim/heal_partition.go
+++ b/swim/heal_partition.go
@@ -72,19 +72,35 @@ func nodesThatNeedToReincarnate(MA, MB []Change) (changesForA, changesForB []Cha
 		// If a node would be overwritten and would stop being pingable, it is
 		// not suited for merging.
 		if b.isPingable() && a.overrides(b) && !a.isPingable() {
-			changesForB = append(changesForB, Change{
-				Address:     a.Address,
-				Incarnation: a.Incarnation,
-				Status:      Suspect,
-			})
+			// take a look at the state of the member
+			member := Member{}
+			member.populateFromChange(&a)
+
+			// create the member into a change
+			change := Change{}
+			change.populateSubject(&member)
+
+			// gossip the suspect status
+			change.Status = Suspect
+
+			// record the change to be sent to B
+			changesForB = append(changesForB, change)
 		}
 
 		if a.isPingable() && b.overrides(a) && !b.isPingable() {
-			changesForA = append(changesForA, Change{
-				Address:     b.Address,
-				Incarnation: b.Incarnation,
-				Status:      Suspect,
-			})
+			// take a look at the state of the member
+			member := Member{}
+			member.populateFromChange(&b)
+
+			// create the member into a change
+			change := Change{}
+			change.populateSubject(&member)
+
+			// gossip the suspect status
+			change.Status = Suspect
+
+			// record the change to be sent to A
+			changesForA = append(changesForA, change)
 		}
 	}
 

--- a/swim/heal_partition.go
+++ b/swim/heal_partition.go
@@ -69,8 +69,6 @@ func nodesThatNeedToReincarnate(MA, MB []Change) (changesForA, changesForB []Cha
 			continue
 		}
 
-		// TODO: DRY
-
 		// If a node would be overwritten and would stop being pingable, it is
 		// not suited for merging.
 		if b.isPingable() && a.overrides(b) && !a.isPingable() {

--- a/swim/heal_partition.go
+++ b/swim/heal_partition.go
@@ -69,16 +69,21 @@ func nodesThatNeedToReincarnate(MA, MB []Change) (changesForA, changesForB []Cha
 			continue
 		}
 
+		// TODO: DRY
+
 		// If a node would be overwritten and would stop being pingable, it is
 		// not suited for merging.
 		if b.isPingable() && a.overrides(b) && !a.isPingable() {
-			// take a look at the state of the member
-			member := Member{}
-			member.populateFromChange(&a)
+			// take the change in a local variable, this protects to inadvertly
+			// changing the type of `a` from a value type to a pointer type.
+			var change Change
+			change = a
 
-			// create the member into a change
-			change := Change{}
-			change.populateSubject(&member)
+			// Remove the source information from the change. If the source
+			// information is present and it is gossiped to the other partition
+			// it might cause the partitions to heal before they are in a safe
+			// state.
+			change.scrubSource()
 
 			// gossip the suspect status
 			change.Status = Suspect
@@ -88,13 +93,16 @@ func nodesThatNeedToReincarnate(MA, MB []Change) (changesForA, changesForB []Cha
 		}
 
 		if a.isPingable() && b.overrides(a) && !b.isPingable() {
-			// take a look at the state of the member
-			member := Member{}
-			member.populateFromChange(&b)
+			// take the change in a local variable, this protects to inadvertly
+			// changing the type of `a` from a value type to a pointer type.
+			var change Change
+			change = b
 
-			// create the member into a change
-			change := Change{}
-			change.populateSubject(&member)
+			// Remove the source information from the change. If the source
+			// information is present and it is gossiped to the other partition
+			// it might cause the partitions to heal before they are in a safe
+			// state.
+			change.scrubSource()
 
 			// gossip the suspect status
 			change.Status = Suspect

--- a/swim/member.go
+++ b/swim/member.go
@@ -22,8 +22,8 @@ package swim
 
 import (
 	"bytes"
-	"fmt"
 	"math/rand"
+	"strconv"
 
 	"github.com/uber/ringpop-go/util"
 )
@@ -70,7 +70,9 @@ func (m *Member) populateFromChange(c *Change) {
 // checksumString fills a buffer that is passed with the contents that this node
 // needs to add to the checksum string.
 func (m Member) checksumString(b *bytes.Buffer) {
-	fmt.Fprintf(b, "%s%s%v", m.Address, m.Status, m.Incarnation)
+	b.WriteString(m.Address)
+	b.WriteString(m.Status)
+	b.WriteString(strconv.FormatInt(m.Incarnation, 10))
 }
 
 // shuffles slice of members pseudo-randomly, returns new slice

--- a/swim/member.go
+++ b/swim/member.go
@@ -87,9 +87,10 @@ func shuffle(members []*Member) []*Member {
 	return newMembers
 }
 
-// shouldProcessGossip evaluates the rules of swim and returns wether the gossip
-// should be processed. eg. Copy the memberstate of the gossip to the known
-// memberstate in the memberlist (creating the member when is does not exist).
+// shouldProcessGossip evaluates the rules of swim and returns whether the
+// gossip should be processed. eg. Copy the memberstate of the gossip to the
+// known memberstate in the memberlist (creating the member when is does not
+// exist).
 func shouldProcessGossip(old *Member, gossip *Member) bool {
 	// tombstones will not be accepted if we have no knowledge about the member
 	if gossip.Status == Tombstone && old == nil {

--- a/swim/member.go
+++ b/swim/member.go
@@ -206,6 +206,11 @@ func (c *Change) populateSource(m *Member) {
 	c.SourceIncarnation = m.Incarnation
 }
 
+func (c *Change) scrubSource() {
+	c.Source = ""
+	c.SourceIncarnation = 0
+}
+
 // suspect interface
 func (c Change) address() string {
 	return c.Address

--- a/swim/member.go
+++ b/swim/member.go
@@ -21,8 +21,9 @@
 package swim
 
 import (
+	"bytes"
+	"fmt"
 	"math/rand"
-	"sync"
 
 	"github.com/uber/ringpop-go/util"
 )
@@ -46,7 +47,6 @@ const (
 
 // A Member is a member in the member list
 type Member struct {
-	sync.RWMutex
 	Address     string `json:"address"`
 	Status      string `json:"status"`
 	Incarnation int64  `json:"incarnationNumber"`
@@ -61,6 +61,18 @@ func (m Member) incarnation() int64 {
 	return m.Incarnation
 }
 
+func (m *Member) populateFromChange(c *Change) {
+	m.Address = c.Address
+	m.Incarnation = c.Incarnation
+	m.Status = c.Status
+}
+
+// checksumString fills a buffer that is passed with the contents that this node
+// needs to add to the checksum string.
+func (m Member) checksumString(b *bytes.Buffer) {
+	fmt.Fprintf(b, "%s%s%v", m.Address, m.Status, m.Incarnation)
+}
+
 // shuffles slice of members pseudo-randomly, returns new slice
 func shuffle(members []*Member) []*Member {
 	newMembers := make([]*Member, len(members), cap(members))
@@ -73,40 +85,49 @@ func shuffle(members []*Member) []*Member {
 	return newMembers
 }
 
-// nonLocalOverride returns wether a change should be applied to the member.
-// This function assumes that the address of the member and the change are
-// equal.
-func (m *Member) nonLocalOverride(change Change) bool {
-	// change is younger than current member
-	if change.Incarnation > m.Incarnation {
+// acceptGossip evaluates the rules of swim to accept the gossip as the new state
+// of the member.
+func acceptGossip(old *Member, gossip *Member) bool {
+	// tombstones will not be accepted if we have no knowledge about the member
+	if gossip.Status == Tombstone && old == nil {
+		return false
+	}
+
+	// accept the gossip if we learn about the member through a gossip
+	if old == nil {
 		return true
 	}
 
-	// change is older than current member
-	if change.Incarnation < m.Incarnation {
+	// gossips with a higher incarnation number will always be accepted since
+	// it is a newer version of the member than we know
+	if gossip.Incarnation > old.Incarnation {
+		return true
+	}
+
+	// gossips with a lower incarnation number will never be accepted as we
+	// have a newer version of the member already
+	if gossip.Incarnation < old.Incarnation {
 		return false
 	}
 
-	// If the incarnation numbers are equal, we look at the state to
-	// determine wether the change overrides this member.
-	return statePrecedence(change.Status) > statePrecedence(m.Status)
-}
+	// now we know that the incarnation number of the gossip and the current
+	// view of the member are the same 'age'. Lets evaluate member state to see
+	// which version to pick
 
-// localOverride returns whether the change will override the state of the local
-// member. When it will override the state the member should reincarnate itself
-// to make sure that other members see this node in a correct state.
-func (m *Member) localOverride(local string, change Change) bool {
-	if m.Address != local {
+	// if the status of the gossip takes precedence over the status of our
+	// current member we will accept the gossip.
+	if statePrecedence(gossip.Status) > statePrecedence(old.Status) {
+		return true
+	}
+
+	if statePrecedence(gossip.Status) < statePrecedence(old.Status) {
 		return false
 	}
 
-	// if the incarnation number of the change is smaller than the current
-	// incarnation number it is not overriding the change
-	if change.Incarnation < m.Incarnation {
-		return false
-	}
-
-	return change.Status == Faulty || change.Status == Suspect || change.Status == Tombstone
+	// we prefer the old member over the gossiped member if they have the same
+	// internal state. This prevents the gossip to be continuously be gossiped
+	// around in the network
+	return false
 }
 
 func statePrecedence(s string) int {
@@ -164,6 +185,23 @@ func (c Change) validateOutgoing() Change {
 		c.Tombstone = true
 	}
 	return c
+}
+
+func (c *Change) populateSubject(m *Member) {
+	if m == nil {
+		return
+	}
+	c.Address = m.Address
+	c.Incarnation = m.Incarnation
+	c.Status = m.Status
+}
+
+func (c *Change) populateSource(m *Member) {
+	if m == nil {
+		return
+	}
+	c.Source = m.Address
+	c.SourceIncarnation = m.Incarnation
 }
 
 // suspect interface

--- a/swim/member.go
+++ b/swim/member.go
@@ -87,9 +87,10 @@ func shuffle(members []*Member) []*Member {
 	return newMembers
 }
 
-// acceptGossip evaluates the rules of swim to accept the gossip as the new state
-// of the member.
-func acceptGossip(old *Member, gossip *Member) bool {
+// shouldProcessGossip evaluates the rules of swim and returns wether the gossip
+// should be processed. eg. Copy the memberstate of the gossip to the known
+// memberstate in the memberlist (creating the member when is does not exist).
+func shouldProcessGossip(old *Member, gossip *Member) bool {
 	// tombstones will not be accepted if we have no knowledge about the member
 	if gossip.Status == Tombstone && old == nil {
 		return false

--- a/swim/member_doc_test.go
+++ b/swim/member_doc_test.go
@@ -1,0 +1,18 @@
+package swim
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func ExampleMember_checksumString_output() {
+	var b bytes.Buffer
+	m := Member{
+		Address:     "192.0.2.1:1234",
+		Status:      Alive,
+		Incarnation: 42,
+	}
+	m.checksumString(&b)
+	fmt.Println(b.String())
+	// Output: 192.0.2.1:1234alive42
+}

--- a/swim/member_test.go
+++ b/swim/member_test.go
@@ -21,7 +21,6 @@
 package swim
 
 import (
-	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -93,17 +92,4 @@ func TestChangeOmitTombstone(t *testing.T) {
 	json.Unmarshal(data, &parsedMap)
 	_, has := parsedMap["tombstone"]
 	assert.False(t, has, "don't expect the tombstone field to be serialized when it is")
-}
-
-func TestMemberChecksumString(t *testing.T) {
-	member := Member{
-		Address:     "192.168.2.1:1234",
-		Status:      Alive,
-		Incarnation: 42,
-	}
-
-	var b bytes.Buffer
-	member.checksumString(&b)
-
-	assert.Equal(t, "192.168.2.1:1234alive42", b.String(), "member checksum serialization failed")
 }

--- a/swim/member_test.go
+++ b/swim/member_test.go
@@ -94,11 +94,11 @@ func TestChangeOmitTombstone(t *testing.T) {
 	assert.False(t, has, "don't expect the tombstone field to be serialized when it is")
 }
 
-var acceptGossipTests = []struct {
-	member *Member
-	gossip *Member
-	accept bool
-	name   string
+var shouldProcessGossipTests = []struct {
+	member  *Member
+	gossip  *Member
+	process bool
+	name    string
 }{
 	// test against unknown members
 	{nil, &Member{Address: "192.0.2.1:1234", Incarnation: 42, Status: Alive}, true, "accept Alive gossip for an unknown member"},
@@ -158,7 +158,7 @@ var acceptGossipTests = []struct {
 }
 
 func TestAcceptGossip(t *testing.T) {
-	for _, test := range acceptGossipTests {
-		assert.Equal(t, test.accept, acceptGossip(test.member, test.gossip), "expected to "+test.name)
+	for _, test := range shouldProcessGossipTests {
+		assert.Equal(t, test.process, shouldProcessGossip(test.member, test.gossip), "expected to "+test.name)
 	}
 }

--- a/swim/member_test.go
+++ b/swim/member_test.go
@@ -21,6 +21,7 @@
 package swim
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -74,52 +75,6 @@ func newChange(addr string, s state) Change {
 	}
 }
 
-func (s *MemberTestSuite) TestNonLocalOverride() {
-	// NonLocalOverride ignores the locallity and only cares about the
-	// incarnation number and status of the members and changes. Since
-	// the state (incNum, status pairs) slice is generated with ever
-	// increasing precendence, changes with index j override members
-	// with index i if and only if j > i.
-	for i, s1 := range s.states {
-		for j, s2 := range s.states {
-			m := newMember(s.localAddr, s1)
-			c := newChange(s.localAddr, s2)
-			expected := j > i
-			got := m.nonLocalOverride(c)
-			s.Equal(expected, got, "expected override if and only if j > i")
-
-			m = newMember(s.nonLocalAddr, s1)
-			c = newChange(s.nonLocalAddr, s2)
-			expected = j > i
-			got = m.nonLocalOverride(c)
-			s.Equal(expected, got, "expected override if and only if j > i")
-		}
-	}
-}
-
-func (s *MemberTestSuite) TestLocalOverride() {
-	// LocalOverride marks updates as overrides when the change will be applied
-	// to the status of this node. It follows the rules of SWIM with regards to
-	// the incarnation number, but is hardcoded to states that the node will
-	// never declare itself to. Meaning that it will allow the node to be in any
-	// of Alive or Leave state.
-	// The Update function reincarnates the node when LocalOverride returns true.
-	for _, s1 := range s.states {
-		for _, s2 := range s.states {
-			m := newMember(s.localAddr, s1)
-			c := newChange(s.localAddr, s2)
-			expected := (c.Status == Suspect || c.Status == Faulty || c.Status == Tombstone) && c.Incarnation >= m.Incarnation
-			got := m.localOverride(s.localAddr, c)
-			s.Equal(expected, got, "expected override when change.Status is suspect or faulty")
-
-			m = newMember(s.nonLocalAddr, s1)
-			c = newChange(s.nonLocalAddr, s2)
-			got = m.localOverride(s.localAddr, c)
-			s.False(got, "expected no override since member is not local")
-		}
-	}
-}
-
 func TestMemberTestSuite(t *testing.T) {
 	suite.Run(t, new(MemberTestSuite))
 }
@@ -138,4 +93,17 @@ func TestChangeOmitTombstone(t *testing.T) {
 	json.Unmarshal(data, &parsedMap)
 	_, has := parsedMap["tombstone"]
 	assert.False(t, has, "don't expect the tombstone field to be serialized when it is")
+}
+
+func TestMemberChecksumString(t *testing.T) {
+	member := Member{
+		Address:     "192.168.2.1:1234",
+		Status:      Alive,
+		Incarnation: 42,
+	}
+
+	var b bytes.Buffer
+	member.checksumString(&b)
+
+	assert.Equal(t, "192.168.2.1:1234alive42", b.String(), "member checksum serialization failed")
 }

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -91,7 +91,7 @@ func (m *memberlist) Checksum() uint32 {
 func (m *memberlist) ComputeChecksum() {
 	startTime := time.Now()
 	m.members.Lock()
-	checksum := farm.Fingerprint32([]byte(m.GenChecksumString()))
+	checksum := farm.Fingerprint32([]byte(m.genChecksumString()))
 	oldChecksum := m.members.checksum
 	m.members.checksum = checksum
 	m.members.Unlock()
@@ -111,7 +111,7 @@ func (m *memberlist) ComputeChecksum() {
 }
 
 // generates string to use when computing checksum
-func (m *memberlist) GenChecksumString() string {
+func (m *memberlist) genChecksumString() string {
 	var strings sort.StringSlice
 	var buffer bytes.Buffer
 

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -242,12 +242,6 @@ func (m *memberlist) GetMembers() (members []Member) {
 	return
 }
 
-// Reincarnate sets the status of the node to Alive and updates the incarnation
-// number. It adds the change to the disseminator as well.
-func (m *memberlist) Reincarnate() []Change {
-	return m.MakeAlive(m.local.Address, nowInMillis(m.node.clock))
-}
-
 // bumpIncarnation will increase the incarnation number of the local member. It
 // will also prepare the change needed to gossip the change to the rest of the
 // network. This function does not update the checksum stored on the membership,

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -198,13 +198,13 @@ func (m *memberlist) Pingable(member Member) bool {
 
 // returns the number of pingable members in the memberlist
 func (m *memberlist) NumPingableMembers() (n int) {
-	m.members.Lock()
+	m.members.RLock()
 	for _, member := range m.members.list {
 		if m.Pingable(*member) {
 			n++
 		}
 	}
-	m.members.Unlock()
+	m.members.RUnlock()
 
 	return n
 }
@@ -233,6 +233,7 @@ func (m *memberlist) RandomPingableMembers(n int, excluding map[string]bool) []*
 // returns an immutable slice of members representing the current state of the membership
 func (m *memberlist) GetMembers() (members []Member) {
 	m.members.RLock()
+	members = make([]Member, 0, len(m.members.list))
 	for _, member := range m.members.list {
 		members = append(members, *member)
 	}
@@ -507,9 +508,8 @@ func (m *memberlist) Iter() *memberlistIter {
 }
 
 func (m *memberlist) GetReachableMembers() []string {
-	var active []string
-
 	m.members.RLock()
+	active := make([]string, 0, len(m.members.list))
 	for _, member := range m.members.list {
 		if member.isReachable() {
 			active = append(active, member.Address)

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -470,7 +470,9 @@ func (m *memberlist) AddJoinList(list []Change) {
 	}
 }
 
-// gets a random position in [0, length of member list)
+// getJoinPosition picks a random position in [0, length of member list), this
+// assumes the caller already has a read lock on the member struct to prevent
+// concurrent access.
 func (m *memberlist) getJoinPosition() int {
 	l := len(m.members.list)
 	if l == 0 {

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -390,23 +390,23 @@ func (m *memberlist) Update(changes []Change) (applied []Change) {
 		gossip := Member{}
 		gossip.populateFromChange(&change)
 
-		// test to see if we accpet the gossip
-		if acceptGossip(member, &gossip) {
-			// the gossip is accepted
+		// test to see if we need to process the gossip
+		if shouldProcessGossip(member, &gossip) {
+			// the gossip overwrites the know state about the member
 
 			if gossip.Address == m.local.Address {
 				// if the gossip is about the local member it needs to be
 				// countered by increasing the incarnation number and gossip the
-				// new change to the network.
+				// new state to the network.
 				change = m.bumpIncarnation()
 				m.node.emit(RefuteUpdateEvent{})
 			} else {
 				// otherwise it can be applied to the memberlist
 
-				// if the member was not already present in the list we will it
-				// needs to be added and randomly inserted in the list to ensure
-				// guarantees for pinging
 				if !has {
+					// if the member was not already present in the list we will
+					// add it and assign it a random position in the list to ensure
+					// guarantees for pinging
 					m.members.byAddress[gossip.Address] = &gossip
 					i := m.getJoinPosition()
 					m.members.list = append(m.members.list[:i], append([]*Member{&gossip}, m.members.list[i:]...)...)

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -418,7 +418,10 @@ func (m *memberlist) Update(changes []Change) (applied []Change) {
 					i := m.getJoinPosition()
 					m.members.list = append(m.members.list[:i], append([]*Member{&gossip}, m.members.list[i:]...)...)
 				} else {
-					// copy the state of the gossip to the member
+					// copy the value of the gossip into the already existing
+					// struct. This operation is by value, not by reference.
+					// this is to keep both the list and byAddress map in sync
+					// without tedious lookup operations.
 					*member = gossip
 				}
 

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -274,20 +274,6 @@ func (m *memberlist) MakeFaulty(address string, incarnation int64) []Change {
 	return m.MakeChange(address, incarnation, Faulty)
 }
 
-// TODO: MakeLeave is only during testing. Need to figure out if we want to keep
-// it around or rewrite the tests.
-func (m *memberlist) MakeLeave(address string, incarnation int64) []Change {
-	// for backwards compatibility in tests we allow to update the local member
-	// in place when the gossip is about the local node and an incarnation number
-	// that is expected to have accept the update.
-	if address == m.local.Address && m.local.Incarnation <= incarnation {
-		m.local.Status = Leave
-	}
-
-	m.node.emit(MakeNodeStatusEvent{Leave})
-	return m.MakeChange(address, incarnation, Leave)
-}
-
 func (m *memberlist) SetLocalStatus(status string) {
 	m.local.Status = status
 	m.postLocalUpdate()

--- a/swim/memberlist_iter_test.go
+++ b/swim/memberlist_iter_test.go
@@ -49,8 +49,19 @@ func (s *MemberlistIterTestSuite) TearDownTest() {
 }
 
 func (s *MemberlistIterTestSuite) TestNoneUseable() {
-	s.m.MakeFaulty("127.0.0.1:3002", s.incarnation)
-	s.m.MakeLeave("127.0.0.1:3003", s.incarnation)
+	// populate the membership with two unusable nodes.
+	s.m.Update([]Change{
+		Change{
+			Address:     "127.0.0.1:3002",
+			Incarnation: s.incarnation,
+			Status:      Faulty,
+		},
+		Change{
+			Address:     "127.0.0.1:3003",
+			Incarnation: s.incarnation,
+			Status:      Leave,
+		},
+	})
 
 	member, ok := s.i.Next()
 	s.Nil(member, "expected member to be nil")
@@ -81,10 +92,12 @@ func (s *MemberlistIterTestSuite) TestIterOverFive() {
 }
 
 func (s *MemberlistIterTestSuite) TestIterSkips() {
-	s.m.MakeAlive("127.0.0.1:3002", s.incarnation)
-	s.m.MakeFaulty("127.0.0.1:3003", s.incarnation)
-	s.m.MakeAlive("127.0.0.1:3004", s.incarnation)
-	s.m.MakeLeave("127.0.0.1:3005", s.incarnation)
+	s.m.Update([]Change{
+		Change{Address: "127.0.0.1:3002", Incarnation: s.incarnation, Status: Alive},
+		Change{Address: "127.0.0.1:3003", Incarnation: s.incarnation, Status: Faulty},
+		Change{Address: "127.0.0.1:3004", Incarnation: s.incarnation, Status: Alive},
+		Change{Address: "127.0.0.1:3005", Incarnation: s.incarnation, Status: Leave},
+	})
 
 	iterated := make(map[string]int)
 

--- a/swim/memberlist_test.go
+++ b/swim/memberlist_test.go
@@ -124,30 +124,6 @@ func (s *MemberlistTestSuite) TestChecksumsEqual() {
 		"expected checksums to be equal")
 }
 
-func (s *MemberlistTestSuite) TestLocalLeaveOverrideHigher() {
-	s.Require().NotNil(s.m.local, "local member cannot be nil")
-
-	s.m.MakeLeave(s.m.local.Address, s.incarnation+1)
-
-	s.Equal(Leave, s.m.local.Status, "expected local member status to be leave")
-}
-
-func (s *MemberlistTestSuite) TestLocalLeaveOverrideEqual() {
-	s.Require().NotNil(s.m.local, "local member cannot be nil")
-
-	s.m.MakeLeave(s.m.local.Address, s.incarnation)
-
-	s.Equal(Leave, s.m.local.Status, "expected local member status to be leave")
-}
-
-func (s *MemberlistTestSuite) TestLocalLeaveOverrideLower() {
-	s.Require().NotNil(s.m.local, "local member cannot be nil")
-
-	s.m.MakeLeave(s.m.local.Address, s.incarnation-1)
-
-	s.Equal(Alive, s.m.local.Status, "expected local member status to be alive")
-}
-
 func (s *MemberlistTestSuite) TestLocalFaultyOverride() {
 	s.Require().NotNil(s.m.local, "local member cannot be nil")
 


### PR DESCRIPTION
With this refactor we keep an explicit copy of what the local state of a member is and reincarnate from there if we receive a gossip that would overwrite the state of our node in the network.

It is analogous to https://github.com/uber/ringpop-node/pull/291