### PR TITLE
Remove MakeLeave as a function from the membership

### DIFF
--- a/swim/gossip_test.go
+++ b/swim/gossip_test.go
@@ -88,10 +88,12 @@ func (s *GossipTestSuite) TestUpdatesArePropagated() {
 	s.node.disseminator.ClearChanges()
 	peer.node.disseminator.ClearChanges()
 
-	peer.node.memberlist.MakeAlive("127.0.0.1:3003", s.incarnation)
-	peer.node.memberlist.MakeFaulty("127.0.0.1:3004", s.incarnation)
-	peer.node.memberlist.MakeSuspect("127.0.0.1:3005", s.incarnation)
-	peer.node.memberlist.MakeLeave("127.0.0.1:3006", s.incarnation)
+	peer.node.memberlist.Update([]Change{
+		Change{Address: "127.0.0.1:3003", Incarnation: s.incarnation, Status: Alive},
+		Change{Address: "127.0.0.1:3004", Incarnation: s.incarnation, Status: Faulty},
+		Change{Address: "127.0.0.1:3005", Incarnation: s.incarnation, Status: Suspect},
+		Change{Address: "127.0.0.1:3006", Incarnation: s.incarnation, Status: Leave},
+	})
 
 	s.Len(peer.node.disseminator.changes, 4)
 

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -274,20 +274,6 @@ func (m *memberlist) MakeFaulty(address string, incarnation int64) []Change {
 	return m.MakeChange(address, incarnation, Faulty)
 }
 
-// TODO: MakeLeave is only during testing. Need to figure out if we want to keep
-// it around or rewrite the tests.
-func (m *memberlist) MakeLeave(address string, incarnation int64) []Change {
-	// for backwards compatibility in tests we allow to update the local member
-	// in place when the gossip is about the local node and an incarnation number
-	// that is expected to have accept the update.
-	if address == m.local.Address && m.local.Incarnation <= incarnation {
-		m.local.Status = Leave
-	}
-
-	m.node.emit(MakeNodeStatusEvent{Leave})
-	return m.MakeChange(address, incarnation, Leave)
-}
-
 func (m *memberlist) SetLocalStatus(status string) {
 	m.local.Status = status
 	m.postLocalUpdate()

--- a/swim/memberlist_iter_test.go
+++ b/swim/memberlist_iter_test.go
@@ -49,8 +49,19 @@ func (s *MemberlistIterTestSuite) TearDownTest() {
 }
 
 func (s *MemberlistIterTestSuite) TestNoneUseable() {
-	s.m.MakeFaulty("127.0.0.1:3002", s.incarnation)
-	s.m.MakeLeave("127.0.0.1:3003", s.incarnation)
+	// populate the membership with two unusable nodes.
+	s.m.Update([]Change{
+		Change{
+			Address:     "127.0.0.1:3002",
+			Incarnation: s.incarnation,
+			Status:      Faulty,
+		},
+		Change{
+			Address:     "127.0.0.1:3003",
+			Incarnation: s.incarnation,
+			Status:      Leave,
+		},
+	})
 
 	member, ok := s.i.Next()
 	s.Nil(member, "expected member to be nil")
@@ -81,10 +92,12 @@ func (s *MemberlistIterTestSuite) TestIterOverFive() {
 }
 
 func (s *MemberlistIterTestSuite) TestIterSkips() {
-	s.m.MakeAlive("127.0.0.1:3002", s.incarnation)
-	s.m.MakeFaulty("127.0.0.1:3003", s.incarnation)
-	s.m.MakeAlive("127.0.0.1:3004", s.incarnation)
-	s.m.MakeLeave("127.0.0.1:3005", s.incarnation)
+	s.m.Update([]Change{
+		Change{Address: "127.0.0.1:3002", Incarnation: s.incarnation, Status: Alive},
+		Change{Address: "127.0.0.1:3003", Incarnation: s.incarnation, Status: Faulty},
+		Change{Address: "127.0.0.1:3004", Incarnation: s.incarnation, Status: Alive},
+		Change{Address: "127.0.0.1:3005", Incarnation: s.incarnation, Status: Leave},
+	})
 
 	iterated := make(map[string]int)
 

--- a/swim/memberlist_test.go
+++ b/swim/memberlist_test.go
@@ -124,30 +124,6 @@ func (s *MemberlistTestSuite) TestChecksumsEqual() {
 		"expected checksums to be equal")
 }
 
-func (s *MemberlistTestSuite) TestLocalLeaveOverrideHigher() {
-	s.Require().NotNil(s.m.local, "local member cannot be nil")
-
-	s.m.MakeLeave(s.m.local.Address, s.incarnation+1)
-
-	s.Equal(Leave, s.m.local.Status, "expected local member status to be leave")
-}
-
-func (s *MemberlistTestSuite) TestLocalLeaveOverrideEqual() {
-	s.Require().NotNil(s.m.local, "local member cannot be nil")
-
-	s.m.MakeLeave(s.m.local.Address, s.incarnation)
-
-	s.Equal(Leave, s.m.local.Status, "expected local member status to be leave")
-}
-
-func (s *MemberlistTestSuite) TestLocalLeaveOverrideLower() {
-	s.Require().NotNil(s.m.local, "local member cannot be nil")
-
-	s.m.MakeLeave(s.m.local.Address, s.incarnation-1)
-
-	s.Equal(Alive, s.m.local.Status, "expected local member status to be alive")
-}
-
 func (s *MemberlistTestSuite) TestLocalFaultyOverride() {
 	s.Require().NotNil(s.m.local, "local member cannot be nil")
 


### PR DESCRIPTION
Remove `MakeLeave` function as it is only used during testing to get the membership into a certain state, instead we will use Update with crafted changes for this as that is the most public interface to interact with the membership.

_NOTE: This PR is on top of #159, its only purpose is to remove `MakeLeave` from the memberlist_

/cc @mennopruijssers 