### PR TITLE
Support imported files in thrift-gen

### DIFF
--- a/ringpop.thrift-gen
+++ b/ringpop.thrift-gen
@@ -14,7 +14,15 @@ import (
     "github.com/uber/ringpop-go/router"
     "github.com/uber/tchannel-go"
     "github.com/uber/tchannel-go/thrift"
+
+{{ range .Includes }}
+    "{{ .Import }}"
+{{ end }}
 )
+
+{{ range .Includes }}
+    var _ = {{ .Package }}.GoUnusedProtection__
+{{ end }}
 
 {{ range .AST.Services }}
 {{ $Service := . }}

--- a/test/remoteservice/.gitignore
+++ b/test/remoteservice/.gitignore
@@ -1,3 +1,4 @@
 *.go
 !*_test.go
 mocks/
+.gen/

--- a/test/remoteservice/remoteservice.thrift
+++ b/test/remoteservice/remoteservice.thrift
@@ -7,5 +7,5 @@ include "./shared.thrift"
 include "./unused.thrift"
 
 service RemoteService {
-  void RemoteCall(1: shared.UUID id)
+  void RemoteCall(1: shared.Name name)
 }

--- a/test/remoteservice/remoteservice.thrift
+++ b/test/remoteservice/remoteservice.thrift
@@ -1,3 +1,5 @@
+include "./shared.thrift"
+
 service RemoteService {
-  void RemoteCall(1: string name)
+  void RemoteCall(1: shared.UUID id)
 }

--- a/test/remoteservice/remoteservice.thrift
+++ b/test/remoteservice/remoteservice.thrift
@@ -1,4 +1,9 @@
 include "./shared.thrift"
+
+// the unused file contains types that are not used in service endpoints. These
+// types might actually be used in embedded structs here, but since the
+// generated code could potentially contain the import of an unused package in
+// the RingpopAdapter. To prevent this the generator uses `GoUnusedProtection__`
 include "./unused.thrift"
 
 service RemoteService {

--- a/test/remoteservice/remoteservice.thrift
+++ b/test/remoteservice/remoteservice.thrift
@@ -1,4 +1,5 @@
 include "./shared.thrift"
+include "./unused.thrift"
 
 service RemoteService {
   void RemoteCall(1: shared.UUID id)

--- a/test/remoteservice/remoteservice_test.go
+++ b/test/remoteservice/remoteservice_test.go
@@ -28,7 +28,7 @@ func TestNewRingpopRemoteServiceAdapter(t *testing.T) {
 
 	adapter, err := NewRingpopRemoteServiceAdapter(serviceImpl, rp, nil, RemoteServiceConfiguration{
 		RemoteCall: &RemoteServiceRemoteCallConfiguration{
-			Key: func(ctx thrift.Context, name shared.UUID) (string, error) {
+			Key: func(ctx thrift.Context, name shared.Name) (string, error) {
 				return string(name), nil
 			},
 		},
@@ -62,22 +62,22 @@ func TestRingpopRemoteServiceAdapterCallLocal(t *testing.T) {
 	rp.On("WhoAmI").Return("127.0.0.1:3000", nil)
 
 	serviceImpl := &servicemocks.TChanRemoteService{}
-	serviceImpl.On("RemoteCall", mock.Anything, shared.UUID("hello")).Return(nil)
+	serviceImpl.On("RemoteCall", mock.Anything, shared.Name("hello")).Return(nil)
 	ctx, _ := thrift.NewContext(0 * time.Second)
 
 	adapter, err := NewRingpopRemoteServiceAdapter(serviceImpl, rp, nil, RemoteServiceConfiguration{
 		RemoteCall: &RemoteServiceRemoteCallConfiguration{
-			Key: func(ctx thrift.Context, name shared.UUID) (string, error) {
+			Key: func(ctx thrift.Context, name shared.Name) (string, error) {
 				return string(name), nil
 			},
 		},
 	})
 	assert.Equal(t, err, nil, "creation of adator gave an error")
 
-	err = adapter.RemoteCall(ctx, shared.UUID("hello"))
+	err = adapter.RemoteCall(ctx, shared.Name("hello"))
 	assert.Equal(t, err, nil, "calling RemoteCall gave an error")
 
-	serviceImpl.AssertCalled(t, "RemoteCall", mock.Anything, shared.UUID("hello"))
+	serviceImpl.AssertCalled(t, "RemoteCall", mock.Anything, shared.Name("hello"))
 }
 
 func TestRingpopRemoteServiceAdapterCallRemote(t *testing.T) {
@@ -87,7 +87,7 @@ func TestRingpopRemoteServiceAdapterCallRemote(t *testing.T) {
 	rp.On("WhoAmI").Return("127.0.0.1:3000", nil)
 
 	serviceImpl := &servicemocks.TChanRemoteService{}
-	serviceImpl.On("RemoteCall", mock.Anything, shared.UUID("hello")).Return(nil)
+	serviceImpl.On("RemoteCall", mock.Anything, shared.Name("hello")).Return(nil)
 	ctx, _ := thrift.NewContext(0 * time.Second)
 
 	ch, err := tchannel.NewChannel("remote", nil)
@@ -95,7 +95,7 @@ func TestRingpopRemoteServiceAdapterCallRemote(t *testing.T) {
 
 	adapter, err := NewRingpopRemoteServiceAdapter(serviceImpl, rp, ch, RemoteServiceConfiguration{
 		RemoteCall: &RemoteServiceRemoteCallConfiguration{
-			Key: func(ctx thrift.Context, name shared.UUID) (string, error) {
+			Key: func(ctx thrift.Context, name shared.Name) (string, error) {
 				return string(name), nil
 			},
 		},
@@ -116,7 +116,7 @@ func TestGetLocalClient(t *testing.T) {
 	rp.On("WhoAmI").Return("127.0.0.1:3000")
 
 	serviceImpl := &servicemocks.TChanRemoteService{}
-	serviceImpl.On("RemoteCall", mock.Anything, shared.UUID("hello")).Return(nil)
+	serviceImpl.On("RemoteCall", mock.Anything, shared.Name("hello")).Return(nil)
 	ctx, _ := thrift.NewContext(0 * time.Second)
 
 	ch, err := tchannel.NewChannel("remote", nil)
@@ -124,7 +124,7 @@ func TestGetLocalClient(t *testing.T) {
 
 	adapter, err := NewRingpopRemoteServiceAdapter(serviceImpl, rp, ch, RemoteServiceConfiguration{
 		RemoteCall: &RemoteServiceRemoteCallConfiguration{
-			Key: func(ctx thrift.Context, name shared.UUID) (string, error) {
+			Key: func(ctx thrift.Context, name shared.Name) (string, error) {
 				return string(name), nil
 			},
 		},
@@ -132,9 +132,9 @@ func TestGetLocalClient(t *testing.T) {
 
 	cf := adapter.(router.ClientFactory)
 	localClient := cf.GetLocalClient().(TChanRemoteService)
-	err = localClient.RemoteCall(ctx, shared.UUID("hello"))
+	err = localClient.RemoteCall(ctx, shared.Name("hello"))
 	assert.Equal(t, err, nil, "calling the local client gave an error")
-	serviceImpl.AssertCalled(t, "RemoteCall", mock.Anything, shared.UUID("hello"))
+	serviceImpl.AssertCalled(t, "RemoteCall", mock.Anything, shared.Name("hello"))
 
 }
 
@@ -145,7 +145,7 @@ func TestMakeRemoteClient(t *testing.T) {
 	rp.On("WhoAmI").Return("127.0.0.1:3000")
 
 	serviceImpl := &servicemocks.TChanRemoteService{}
-	serviceImpl.On("RemoteCall", mock.Anything, shared.UUID("hello")).Return(nil)
+	serviceImpl.On("RemoteCall", mock.Anything, shared.Name("hello")).Return(nil)
 	ctx, _ := thrift.NewContext(0 * time.Second)
 
 	ch, err := tchannel.NewChannel("remote", nil)
@@ -153,19 +153,19 @@ func TestMakeRemoteClient(t *testing.T) {
 
 	adapter, err := NewRingpopRemoteServiceAdapter(serviceImpl, rp, ch, RemoteServiceConfiguration{
 		RemoteCall: &RemoteServiceRemoteCallConfiguration{
-			Key: func(ctx thrift.Context, name shared.UUID) (string, error) {
+			Key: func(ctx thrift.Context, name shared.Name) (string, error) {
 				return string(name), nil
 			},
 		},
 	})
 
 	tchanClient := &mocks.TChanClient{}
-	tchanClient.On("Call", mock.Anything, "RemoteService", "RemoteCall", &RemoteServiceRemoteCallArgs{ID: shared.UUID("hello")}, mock.Anything).Return(true, nil)
+	tchanClient.On("Call", mock.Anything, "RemoteService", "RemoteCall", &RemoteServiceRemoteCallArgs{Name: shared.Name("hello")}, mock.Anything).Return(true, nil)
 
 	cf := adapter.(router.ClientFactory)
 	remoteClient := cf.MakeRemoteClient(tchanClient).(TChanRemoteService)
-	err = remoteClient.RemoteCall(ctx, shared.UUID("hello"))
+	err = remoteClient.RemoteCall(ctx, shared.Name("hello"))
 	assert.Equal(t, err, nil, "calling the remote client gave an error")
 
-	tchanClient.AssertCalled(t, "Call", mock.Anything, "RemoteService", "RemoteCall", &RemoteServiceRemoteCallArgs{ID: shared.UUID("hello")}, mock.Anything)
+	tchanClient.AssertCalled(t, "Call", mock.Anything, "RemoteService", "RemoteCall", &RemoteServiceRemoteCallArgs{Name: shared.Name("hello")}, mock.Anything)
 }

--- a/test/remoteservice/shared.thrift
+++ b/test/remoteservice/shared.thrift
@@ -1,0 +1,1 @@
+typedef string UUID

--- a/test/remoteservice/shared.thrift
+++ b/test/remoteservice/shared.thrift
@@ -1,1 +1,1 @@
-typedef string UUID
+typedef string Name

--- a/test/remoteservice/unused.thrift
+++ b/test/remoteservice/unused.thrift
@@ -1,0 +1,1 @@
+typedef string UnusedType


### PR DESCRIPTION
This PR adds support for imported thrift files during the code generation phase.

`GoUnusedProtection__` is the same trick as used in [`thrift-gen`](https://github.com/uber/tchannel-go/blob/v1.0.9/thrift/thrift-gen/tchannel-template.go#L22)