### PR TITLE
Fix Flappy Stats Test

### DIFF
--- a/swim/stats_test.go
+++ b/swim/stats_test.go
@@ -68,7 +68,7 @@ func (s *StatsTestSuite) TestProtocolStats() {
 
 	// We need to sleep for at least 5 seconds, as this is the tick period for
 	// the metrics.Meter and it cannot be easily changed.
-	time.Sleep(5 * time.Second)
+	time.Sleep(6 * time.Second)
 
 	stats := s.testNode.node.ProtocolStats()
 


### PR DESCRIPTION
This PR is in the hope to fix a flappy test that happens more often than not:

```
--- FAIL: TestProtocolStats (5.09s)
    Error Trace:    stats_test.go:89
    Error:      Should not be zero, but was 0

    Error Trace:    stats_test.go:90
    Error:      Should not be zero, but was 0

--- FAIL: TestStatsTestSuite (5.21s)
FAIL
FAIL    github.com/uber/ringpop-go/swim 9.984s
```

The reasoning behind the change is that `metrics.Meter` mentioned in the comments above is snapshotted every 5 seconds and made available to read from. By exactly waiting 5 seconds we might still read the values just before the snapshot is actually populated with information. By waiting an additional second the hope is that we read less 0's.