### PR TITLE
Use narrower duck-typing instead of embedding whole interface

### DIFF
--- a/shared/interfaces.go
+++ b/shared/interfaces.go
@@ -4,7 +4,7 @@ import "github.com/uber/tchannel-go"
 
 // The TChannel interface defines the dependencies for TChannel in Ringpop.
 type TChannel interface {
-	tchannel.Registrar
+	Register(h tchannel.Handler, methodName string)
 	PeerInfo() tchannel.LocalPeerInfo
 	GetSubChannel(string, ...tchannel.SubChannelOption) *tchannel.SubChannel
 }


### PR DESCRIPTION
Recreating #165 to merge to `dev` instead of `master`

---
The `tchannel.Registrar` interface has been extended with an extra method, and there are compile errors in our internal go-common library against ringpop-go/0.6.0

ringpop does not need the whole `tchannel.Registrar` interface in its duck-typed TChannel  interface, just the Register() method.
