### PR TITLE
Fix: Examples Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ env:
 matrix:
   allow_failures:
     - env: RUN="make test-race"
-    - env: RUN="make test-examples"
 
   fast_finish: true
 

--- a/examples/ping-json/README.md
+++ b/examples/ping-json/README.md
@@ -22,7 +22,7 @@ Lookup the node `my_key` key belongs to using [tcurl][2]:
 Call the `/ping` endpoint (multiple times) and see the request being forwarded. Each request is sent to a random node in the cluster because of the `-P hosts.json` argument--but is always handled by the node owning the key. This can be seen in the `from` field of the response:
 
     $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}'
-    {"ok":true,"head":null,"body":{"message":"Hello, world!","from":"127.0.0.1:300?","p":""},"headers":{"as":"json"},"trace":"*"} (glob)
+    {"ok":true,"head":null,"body":{"message":"Hello, world!","from":"127.0.0.1:300?","pheader":""},"headers":{"as":"json"},"trace":"*"} (glob)
 
 Optionally, set the `p` header. This value will be forwarded together with the request body to the node owning the key. Its value is returned in the response body in the `pheader` field:
 

--- a/examples/ping-thrift-gen/README.md
+++ b/examples/ping-thrift-gen/README.md
@@ -35,7 +35,7 @@ Call the `PingPongService::Ping` endpoint (multiple times) and see the request b
 
 Optionally, set the `p` header. This value will be forwarded together with the request body to the node owning the key. Its value is returned in the response body in the `pheader` field:
 
-    $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
+    $ tcurl pingchannel -P hosts.json --thrift ./ping.thrift PingPongService::Ping '{"request": {"key": "my_key"}}' --headers '{"p": "my_header"}'
     {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"thrift"},"trace":"*"} (glob)
 
     $ kill %1

--- a/examples/ping-thrift-gen/gen-go/ping/tchan-ping.go
+++ b/examples/ping-thrift-gen/gen-go/ping/tchan-ping.go
@@ -71,23 +71,45 @@ func (s *tchanPingPongServiceServer) Methods() []string {
 }
 
 func (s *tchanPingPongServiceServer) Handle(ctx thrift.Context, methodName string, protocol athrift.TProtocol) (bool, athrift.TStruct, error) {
+	args, err := s.GetArgs(methodName, protocol)
+	if err != nil {
+		return false, nil, err
+	}
+	return s.HandleArgs(ctx, methodName, args)
+}
+
+func (s *tchanPingPongServiceServer) GetArgs(methodName string, protocol athrift.TProtocol) (args interface{}, err error) {
 	switch methodName {
 	case "Ping":
-		return s.handlePing(ctx, protocol)
+		args, err = s.readPing(protocol)
+
+	default:
+		err = fmt.Errorf("method %v not found in service %v", methodName, s.Service())
+	}
+	return
+}
+
+func (s *tchanPingPongServiceServer) HandleArgs(ctx thrift.Context, methodName string, args interface{}) (bool, athrift.TStruct, error) {
+	switch methodName {
+	case "Ping":
+		return s.handlePing(ctx, args.(PingPongServicePingArgs))
 
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
 	}
 }
 
-func (s *tchanPingPongServiceServer) handlePing(ctx thrift.Context, protocol athrift.TProtocol) (bool, athrift.TStruct, error) {
+func (s *tchanPingPongServiceServer) readPing(protocol athrift.TProtocol) (interface{}, error) {
 	var req PingPongServicePingArgs
-	var res PingPongServicePingResult
 
 	if err := req.Read(protocol); err != nil {
-		return false, nil, err
+		return nil, err
 	}
+	return req, nil
+}
 
+func (s *tchanPingPongServiceServer) handlePing(ctx thrift.Context, req PingPongServicePingArgs) (bool, athrift.TStruct, error) {
+	var res PingPongServicePingResult
 	r, err :=
 		s.handler.Ping(ctx, req.Request)
 

--- a/examples/ping-thrift-gen/main.go
+++ b/examples/ping-thrift-gen/main.go
@@ -92,7 +92,11 @@ func (w *worker) Ping(ctx thrift.Context, request *gen.Ping) (*gen.Pong, error) 
 	}
 	headers := ctx.Headers()
 	pHeader := headers["p"]
-	return &gen.Pong{"Hello, world!", identity, &pHeader}, nil
+	return &gen.Pong{
+		Message: "Hello, world!",
+		From_:   identity,
+		Pheader: &pHeader,
+	}, nil
 }
 
 func main() {

--- a/examples/ping-thrift/README.md
+++ b/examples/ping-thrift/README.md
@@ -34,7 +34,7 @@ Call the `PingPongService::Ping` endpoint (multiple times) and see the request b
 
 Optionally, set the `p` header. This value will be forwarded together with the request body to the node owning the key. Its value is returned in the response body in the `pheader` field:
 
-    $ tcurl pingchannel -P hosts.json /ping '{"key": "my_key"}' --headers '{"p": "my_header"}'
+    $ tcurl pingchannel -P hosts.json --thrift ./ping.thrift PingPongService::Ping '{"request": {"key": "my_key"}}' --headers '{"p": "my_header"}'
     {"ok":true,"head":{},"body":{"message":"Hello, world!","from_":"127.0.0.1:300?","pheader":"my_header"},"headers":{"as":"thrift"},"trace":"*"} (glob)
 
     $ kill %1

--- a/examples/ping-thrift/gen-go/ping/tchan-ping.go
+++ b/examples/ping-thrift/gen-go/ping/tchan-ping.go
@@ -71,23 +71,45 @@ func (s *tchanPingPongServiceServer) Methods() []string {
 }
 
 func (s *tchanPingPongServiceServer) Handle(ctx thrift.Context, methodName string, protocol athrift.TProtocol) (bool, athrift.TStruct, error) {
+	args, err := s.GetArgs(methodName, protocol)
+	if err != nil {
+		return false, nil, err
+	}
+	return s.HandleArgs(ctx, methodName, args)
+}
+
+func (s *tchanPingPongServiceServer) GetArgs(methodName string, protocol athrift.TProtocol) (args interface{}, err error) {
 	switch methodName {
 	case "Ping":
-		return s.handlePing(ctx, protocol)
+		args, err = s.readPing(protocol)
+
+	default:
+		err = fmt.Errorf("method %v not found in service %v", methodName, s.Service())
+	}
+	return
+}
+
+func (s *tchanPingPongServiceServer) HandleArgs(ctx thrift.Context, methodName string, args interface{}) (bool, athrift.TStruct, error) {
+	switch methodName {
+	case "Ping":
+		return s.handlePing(ctx, args.(PingPongServicePingArgs))
 
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
 	}
 }
 
-func (s *tchanPingPongServiceServer) handlePing(ctx thrift.Context, protocol athrift.TProtocol) (bool, athrift.TStruct, error) {
+func (s *tchanPingPongServiceServer) readPing(protocol athrift.TProtocol) (interface{}, error) {
 	var req PingPongServicePingArgs
-	var res PingPongServicePingResult
 
 	if err := req.Read(protocol); err != nil {
-		return false, nil, err
+		return nil, err
 	}
+	return req, nil
+}
 
+func (s *tchanPingPongServiceServer) handlePing(ctx thrift.Context, req PingPongServicePingArgs) (bool, athrift.TStruct, error) {
+	var res PingPongServicePingResult
 	r, err :=
 		s.handler.Ping(ctx, req.Request)
 

--- a/examples/ping-thrift/main.go
+++ b/examples/ping-thrift/main.go
@@ -63,7 +63,9 @@ func (w *worker) Ping(ctx thrift.Context, request *gen.Ping) (*gen.Pong, error) 
 		return nil, err
 	}
 
-	pingArgs := &gen.PingPongServicePingArgs{request}
+	pingArgs := &gen.PingPongServicePingArgs{
+		Request: request,
+	}
 	req, err := ringpop.SerializeThrift(pingArgs)
 	if err != nil {
 		return nil, err
@@ -77,7 +79,11 @@ func (w *worker) Ping(ctx thrift.Context, request *gen.Ping) (*gen.Pong, error) 
 			return nil, err
 		}
 		pHeader := headers["p"]
-		return &gen.Pong{"Hello, world!", identity, &pHeader}, nil
+		return &gen.Pong{
+			Message: "Hello, world!",
+			From_:   identity,
+			Pheader: &pHeader,
+		}, nil
 	}
 
 	if err := ringpop.DeserializeThrift(res, &pongResult); err != nil {


### PR DESCRIPTION
During the development of labels I needed to add an example and documentation for the new feature. To make sure that the example works before merging I would like to let travis tell me whether or not `make test-examples` works. This fixes all existing examples and as a bonus solves a couple of the linting issues `make lint` complains about after the examples have been built locally which has been discussed in #160.

#160 cannot be closed yet because we still didn't solve the problem where the linter is not ran on the examples on travis.