### PR TITLE
[Labels] Implement sane limits on Labels.

### DIFF
--- a/options.go
+++ b/options.go
@@ -47,6 +47,10 @@ type configuration struct {
 
 	// StateTimeouts keeps the state transition timeouts for swim to use
 	StateTimeouts swim.StateTimeouts
+
+	// LabelLimits keeps track of configured limits on labels. Among things the
+	// number of labels and the size of key and value can be configured.
+	LabelLimits swim.LabelOptions
 }
 
 // An Option is a modifier functions that configure/modify a real Ringpop
@@ -276,6 +280,31 @@ func FaultyPeriod(period time.Duration) Option {
 func TombstonePeriod(period time.Duration) Option {
 	return func(r *Ringpop) error {
 		r.config.StateTimeouts.Tombstone = period
+		return nil
+	}
+}
+
+// LabelLimitCount limits the number of labels an application can set on this
+// node.
+func LabelLimitCount(count int) Option {
+	return func(r *Ringpop) error {
+		r.config.LabelLimits.Count = count
+		return nil
+	}
+}
+
+// LabelLimitKeySize limits the size that a key of a label can be.
+func LabelLimitKeySize(size int) Option {
+	return func(r *Ringpop) error {
+		r.config.LabelLimits.KeySize = size
+		return nil
+	}
+}
+
+// LabelLimitValueSize limits the size that a value of a label can be.
+func LabelLimitValueSize(size int) Option {
+	return func(r *Ringpop) error {
+		r.config.LabelLimits.ValueSize = size
 		return nil
 	}
 }

--- a/ringpop.go
+++ b/ringpop.go
@@ -174,6 +174,7 @@ func (rp *Ringpop) init() error {
 	rp.node = swim.NewNode(rp.config.App, address, rp.subChannel, &swim.Options{
 		StateTimeouts: rp.config.StateTimeouts,
 		Clock:         rp.clock,
+		LabelLimits:   rp.config.LabelLimits,
 	})
 	rp.node.RegisterListener(rp)
 

--- a/swim/labels.go
+++ b/swim/labels.go
@@ -18,7 +18,7 @@ var (
 	//    memberlist being sent over the wire 5 times a second.
 	// When all contiditions are met the Labels would add the following load
 	// (non-compressed) to the network:
-	//    (32+128)*5*1000*5*8 = ~32mbit
+	//    (32+128)*5*1000*5*8 = ~32mbit/s
 	DefaultLabelOptions = LabelOptions{
 		KeySize:   32,
 		ValueSize: 128,

--- a/swim/labels.go
+++ b/swim/labels.go
@@ -3,15 +3,141 @@ package swim
 import (
 	"errors"
 	"strings"
+
+	"github.com/uber/ringpop-go/util"
 )
 
 var (
+	// DefaultLabelOptions contain the default values to be used to limit the
+	// amount of data being gossipped over the network. The defaults have been
+	// chosen with the following assumptions.
+	// 1. 1000 node cluster
+	// 2. Every byte available is used (yes, characters are not bytes but these
+	//    are ballpark figures to protect developers)
+	// 3. Worst case would have continues fullsync's, meaning the complete
+	//    memberlist being sent over the wire 5 times a second.
+	// When all contiditions are met the Labels would add the following load
+	// (non-compressed) to the network:
+	//    (32+128)*5*1000*5*8 = ~32mbit
+	DefaultLabelOptions = LabelOptions{
+		KeySize:   32,
+		ValueSize: 128,
+		Count:     5,
+	}
+
+	// ErrLabelSizeExceeded indicates that an operation on labels would exceed
+	// the configured size limits on labels. This is to prevent applications
+	// bloating the gossip protocol with too much data. Ringpop can be
+	// configured with the settings to control the amount of data that can be
+	// put in a nodes labels.
+	ErrLabelSizeExceeded = errors.New("label operation exceeds configured label limits")
+
 	// ErrLabelInternalKey is an error that is returned when an application
 	// tries to set a label in the internal namespace that is used by ringpop
 	ErrLabelInternalKey = errors.New("label can't be altered by application because it is in the internal ringpop namespace")
 
 	labelsInternalNamespacePrefix = "__"
 )
+
+// LabelOptions controlls the limits on labels. Since labels are gossiped on
+// every ping/ping-req/fullsync we need to limit the amount of data an
+// application stores in their labels. When needed the defaults can be
+// overwritten during the construction of ringpop. This should be done with care
+// to not overwhelm the network with data.
+type LabelOptions struct {
+	// KeySize is the length a key may use at most
+	KeySize int
+
+	// ValueSize is the length a value may use at most
+	ValueSize int
+
+	// Count is the number of maximum allowed (public) labels on a node
+	Count int
+}
+
+func mergeLabelOptions(opts LabelOptions, def LabelOptions) LabelOptions {
+	return LabelOptions{
+		KeySize:   util.SelectInt(opts.KeySize, def.KeySize),
+		ValueSize: util.SelectInt(opts.ValueSize, def.ValueSize),
+		Count:     util.SelectInt(opts.Count, def.Count),
+	}
+}
+
+func (lo LabelOptions) validateLabel(current map[string]string, key, value string) error {
+	if isInternalLabel(key) {
+		// we ignore internal labels in the limits
+		return nil
+	}
+
+	if len(key) > lo.KeySize || len(value) > lo.ValueSize {
+		// if the either the key or the value of the label is bigger then
+		// the max allowed size an error is returned
+		return ErrLabelSizeExceeded
+	}
+
+	// keep track of all labels that are new in this operation to calculate if
+	// we are exceeding the maximum allowed number of labels
+	additionalLabelCount := 0
+
+	_, has := current[key]
+	if !has {
+		// only add a count to the countAfter if the key we are looking
+		// at is a new key
+		additionalLabelCount++
+	}
+
+	// get the count of the current labels, internal labels will not be counted
+	currentCount := countNonInternalLabels(current)
+
+	if additionalLabelCount > 0 && (currentCount+additionalLabelCount) > lo.Count {
+		// Only when we add additional labels we check if the new count
+		// (exluding internal labels) will exceed the amount of labels that is
+		// configured. If that is the case we will return an error
+		return ErrLabelSizeExceeded
+	}
+
+	// all is ok
+	return nil
+}
+
+func (lo LabelOptions) validateLabels(current map[string]string, additional map[string]string) error {
+	// keep track of all labels that are new in this operation to calculate if
+	// we are exceeding the maximum allowed number of labels
+	additionalLabelCount := 0
+
+	for key, value := range additional {
+		if isInternalLabel(key) {
+			// we ignore internal labels in the limits
+			continue
+		}
+
+		if len(key) > lo.KeySize || len(value) > lo.ValueSize {
+			// if the either the key or the value of the label is bigger then
+			// the max allowed size an error is returned
+			return ErrLabelSizeExceeded
+		}
+
+		_, has := current[key]
+		if !has {
+			// only add a count to the countAfter if the key we are looking
+			// at is a new key
+			additionalLabelCount++
+		}
+	}
+
+	// get the count of the current labels, internal labels will not be counted
+	currentCount := countNonInternalLabels(current)
+
+	if additionalLabelCount > 0 && (currentCount+additionalLabelCount) > lo.Count {
+		// Only when we add additional labels we check if the new count
+		// (exluding internal labels) will exceed the amount of labels that is
+		// configured. If that is the case we will return an error
+		return ErrLabelSizeExceeded
+	}
+
+	// all is ok
+	return nil
+}
 
 func isInternalLabel(key string) bool {
 	return strings.HasPrefix(key, labelsInternalNamespacePrefix)

--- a/swim/labels_test.go
+++ b/swim/labels_test.go
@@ -1,9 +1,95 @@
 package swim
 
 import (
-	"github.com/stretchr/testify/assert"
-
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	fixtureExceedKeySize         = strings.Repeat("a", 33)
+	fixtureExceedKeySizeInternal = labelsInternalNamespacePrefix + strings.Repeat("a", 33)
+	fixtureExceedValueSize       = strings.Repeat("b", 129)
+
+	fixtureLabelsOneNew = map[string]string{
+		"newkey": "some value",
+	}
+
+	fixtureLabelsOneOverwrite = map[string]string{
+		"key1": "new value for 1",
+	}
+
+	fixtureLabelsInternalNew = map[string]string{
+		"__internal2": "internal value2",
+	}
+
+	fixtureLabelsCombinationNew = map[string]string{
+		"newkey":      "some value",
+		"__internal2": "internal value2",
+	}
+
+	fixtureLabelsCombinationOverwrite = map[string]string{
+		"key1":        "new value for 1",
+		"__internal1": "internal value1",
+	}
+
+	fixtureLabelsRoom = map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+		"key4": "value4",
+	}
+
+	fixtureLabelsRoomWithInternal = map[string]string{
+		"key1":        "value1",
+		"key2":        "value2",
+		"key3":        "value3",
+		"key4":        "value4",
+		"__internal1": "internal value1",
+	}
+
+	fixtureExactLabels = map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+		"key4": "value4",
+		"key5": "value5",
+	}
+
+	fixtureExactLabelsWithInternal = map[string]string{
+		"key1":        "value1",
+		"key2":        "value2",
+		"key3":        "value3",
+		"key4":        "value4",
+		"key5":        "value5",
+		"__internal1": "internal value1",
+	}
+
+	fixtureTooBigLabels = map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+		"key4": "value4",
+		"key5": "value5",
+		"key6": "value6",
+	}
+
+	fixtureTooBigLabelsWithInternal = map[string]string{
+		"key1":        "value1",
+		"key2":        "value2",
+		"key3":        "value3",
+		"key4":        "value4",
+		"key5":        "value5",
+		"key6":        "value6",
+		"__internal1": "internal value1",
+	}
+
+	fixtureLabelOptions = LabelOptions{
+		KeySize:   32,
+		ValueSize: 128,
+		Count:     5,
+	}
 )
 
 var isInternalLabelTests = []struct {
@@ -18,6 +104,211 @@ func TestIsInternalLabel(t *testing.T) {
 	for _, test := range isInternalLabelTests {
 		assert.Equal(t, test.internal, isInternalLabel(test.key), test)
 	}
+}
+
+func TestMergeLabelOptions(t *testing.T) {
+	empty := LabelOptions{}
+	merged := mergeLabelOptions(empty, fixtureLabelOptions)
+	assert.Equal(t, fixtureLabelOptions, merged, "expected an empty LabelOptions struct to equal the fixtureLabelOptions when merged")
+
+	onlyKeySize := LabelOptions{KeySize: 1}
+	merged = mergeLabelOptions(onlyKeySize, fixtureLabelOptions)
+	assert.Equal(t, 1, merged.KeySize, "expected the KeySize to be set to the value set in the optional LabelOptions")
+	assert.Equal(t, fixtureLabelOptions.ValueSize, merged.ValueSize, "expected the ValueSize to be taken from the default options")
+	assert.Equal(t, fixtureLabelOptions.Count, merged.Count, "expected the Count to be taken from the default options")
+
+	onlyValueSize := LabelOptions{ValueSize: 1}
+	merged = mergeLabelOptions(onlyValueSize, fixtureLabelOptions)
+	assert.Equal(t, 1, merged.ValueSize, "expected the ValueSize to be set to the value set in the optional LabelOptions")
+	assert.Equal(t, fixtureLabelOptions.KeySize, merged.KeySize, "expected the KeySize to be taken from the default options")
+	assert.Equal(t, fixtureLabelOptions.Count, merged.Count, "expected the Count to be taken from the default options")
+
+	onlyCount := LabelOptions{Count: 1}
+	merged = mergeLabelOptions(onlyCount, fixtureLabelOptions)
+	assert.Equal(t, 1, merged.Count, "expected the Count to be set to the value set in the optional LabelOptions")
+	assert.Equal(t, fixtureLabelOptions.ValueSize, merged.ValueSize, "expected the ValueSize to be taken from the default options")
+	assert.Equal(t, fixtureLabelOptions.KeySize, merged.KeySize, "expected the KeySize to be taken from the default options")
+}
+
+func TestLabelOptions_validateLabel(t *testing.T) {
+	var err error
+
+	err = fixtureLabelOptions.validateLabel(fixtureLabelsRoom, "newkey", "some value")
+	assert.NoError(t, err, "expected to be able to add a label when there is room in the map")
+
+	err = fixtureLabelOptions.validateLabel(fixtureLabelsRoomWithInternal, "newkey", "some value")
+	assert.NoError(t, err, "expected to be able to add a label when there is room in the map (with internal)")
+
+	err = fixtureLabelOptions.validateLabel(fixtureLabelsRoom, "key1", "new value for 1")
+	assert.NoError(t, err, "expected to be able to overwrite a label when there is room")
+
+	err = fixtureLabelOptions.validateLabel(fixtureLabelsRoomWithInternal, "key1", "new value for 1")
+	assert.NoError(t, err, "expected to be able to overwrite a label when there is room (with internal)")
+
+	err = fixtureLabelOptions.validateLabel(fixtureExactLabels, "newkey", "some value")
+	assert.Error(t, err, "expected an error when adding a new key to a map that is at capacity")
+
+	err = fixtureLabelOptions.validateLabel(fixtureExactLabelsWithInternal, "newkey", "some value")
+	assert.Error(t, err, "expected an error when adding a new key to a map that is at capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabel(fixtureExactLabels, "key1", "new value for 1")
+	assert.NoError(t, err, "expected to be able to overwrite a label even though the map is at capacity")
+
+	err = fixtureLabelOptions.validateLabel(fixtureExactLabelsWithInternal, "key1", "new value for 1")
+	assert.NoError(t, err, "expected to be able to overwrite a label even though the map is at capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabel(fixtureTooBigLabels, "newkey", "some value")
+	assert.Error(t, err, "expected an error when adding a new key to a map that is over capacity")
+
+	err = fixtureLabelOptions.validateLabel(fixtureTooBigLabelsWithInternal, "newkey", "some value")
+	assert.Error(t, err, "expected an error when adding a new key to a map that is over capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabel(fixtureTooBigLabels, "key1", "new value for 1")
+	assert.NoError(t, err, "expected no error when overwriting a key on a map that is over capacity")
+
+	err = fixtureLabelOptions.validateLabel(fixtureTooBigLabelsWithInternal, "key1", "new value for 1")
+	assert.NoError(t, err, "expected no error when overwriting a key on a map that is over capacity (with internal)")
+
+	// make sure that internal labels are still accepted to allow for ringpop internals to proceed
+	err = fixtureLabelOptions.validateLabel(fixtureLabelsRoom, "__internal2", "internal value2")
+	assert.NoError(t, err, "expected no error when adding a internal label when there is room in the map")
+
+	err = fixtureLabelOptions.validateLabel(fixtureLabelsRoomWithInternal, "__internal2", "internal value2")
+	assert.NoError(t, err, "expected no error when adding a internal label when there is room in the map (with internal)")
+
+	err = fixtureLabelOptions.validateLabel(fixtureExactLabels, "__internal2", "internal value2")
+	assert.NoError(t, err, "expected no error when adding a internal label to a map that is at capacity")
+
+	err = fixtureLabelOptions.validateLabel(fixtureExactLabelsWithInternal, "__internal2", "internal value2")
+	assert.NoError(t, err, "expected no error when adding a internal label to a map that is at capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabel(fixtureTooBigLabels, "__internal2", "internal value2")
+	assert.NoError(t, err, "expected no error when adding a internal label when the map is over capacity")
+
+	err = fixtureLabelOptions.validateLabel(fixtureTooBigLabelsWithInternal, "__internal2", "internal value2")
+	assert.NoError(t, err, "expected no error when adding a internal label when the map is over capacity (with internal)")
+
+	// tests for key and value size exceeding
+	err = fixtureLabelOptions.validateLabel(fixtureLabelsRoom, fixtureExceedKeySize, "some value")
+	assert.Error(t, err, "expected error when the key length exceeds the configured length")
+
+	err = fixtureLabelOptions.validateLabel(fixtureLabelsRoom, "newkey", fixtureExceedValueSize)
+	assert.Error(t, err, "expected error when the value length exceeds the configured length")
+
+	err = fixtureLabelOptions.validateLabel(fixtureLabelsRoom, fixtureExceedKeySizeInternal, "some value")
+	assert.NoError(t, err, "expected no error when the key length exceeds the configured length for a internal key")
+
+	err = fixtureLabelOptions.validateLabel(fixtureLabelsRoom, fixtureExceedKeySizeInternal, fixtureExceedValueSize)
+	assert.NoError(t, err, "expected no error when the value length exceeds the configured length for a internal key")
+}
+
+func TestLabelOptions_validateLabels(t *testing.T) {
+	var err error
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoom, fixtureLabelsOneNew)
+	assert.NoError(t, err, "expected to be able to add a label when there is room in the map")
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoomWithInternal, fixtureLabelsOneNew)
+	assert.NoError(t, err, "expected to be able to add a label when there is room in the map (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoom, fixtureLabelsOneOverwrite)
+	assert.NoError(t, err, "expected to be able to overwrite a label when there is room")
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoomWithInternal, fixtureLabelsOneOverwrite)
+	assert.NoError(t, err, "expected to be able to overwrite a label when there is room (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureExactLabels, fixtureLabelsOneNew)
+	assert.Error(t, err, "expected an error when adding a new key to a map that is at capacity")
+
+	err = fixtureLabelOptions.validateLabels(fixtureExactLabelsWithInternal, fixtureLabelsOneNew)
+	assert.Error(t, err, "expected an error when adding a new key to a map that is at capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureExactLabels, fixtureLabelsOneOverwrite)
+	assert.NoError(t, err, "expected to be able to overwrite a label even though the map is at capacity")
+
+	err = fixtureLabelOptions.validateLabels(fixtureExactLabelsWithInternal, fixtureLabelsOneOverwrite)
+	assert.NoError(t, err, "expected to be able to overwrite a label even though the map is at capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureTooBigLabels, fixtureLabelsOneNew)
+	assert.Error(t, err, "expected an error when adding a new key to a map that is over capacity")
+
+	err = fixtureLabelOptions.validateLabels(fixtureTooBigLabelsWithInternal, fixtureLabelsOneNew)
+	assert.Error(t, err, "expected an error when adding a new key to a map that is over capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureTooBigLabels, fixtureLabelsOneOverwrite)
+	assert.NoError(t, err, "expected no error when overwriting a key on a map that is over capacity")
+
+	err = fixtureLabelOptions.validateLabels(fixtureTooBigLabelsWithInternal, fixtureLabelsOneOverwrite)
+	assert.NoError(t, err, "expected no error when overwriting a key on a map that is over capacity (with internal)")
+
+	// make sure that internal labels are still accepted to allow for ringpop internals to proceed
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoom, fixtureLabelsInternalNew)
+	assert.NoError(t, err, "expected no error when adding a internal label when there is room in the map")
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoomWithInternal, fixtureLabelsInternalNew)
+	assert.NoError(t, err, "expected no error when adding a internal label when there is room in the map (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureExactLabels, fixtureLabelsInternalNew)
+	assert.NoError(t, err, "expected no error when adding a internal label to a map that is at capacity")
+
+	err = fixtureLabelOptions.validateLabels(fixtureExactLabelsWithInternal, fixtureLabelsInternalNew)
+	assert.NoError(t, err, "expected no error when adding a internal label to a map that is at capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureTooBigLabels, fixtureLabelsInternalNew)
+	assert.NoError(t, err, "expected no error when adding a internal label when the map is over capacity")
+
+	err = fixtureLabelOptions.validateLabels(fixtureTooBigLabelsWithInternal, fixtureLabelsInternalNew)
+	assert.NoError(t, err, "expected no error when adding a internal label when the map is over capacity (with internal)")
+
+	// tests for key and value size exceeding
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoom, map[string]string{fixtureExceedKeySize: "some value"})
+	assert.Error(t, err, "expected error when the key length exceeds the configured length")
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoom, map[string]string{"newkey": fixtureExceedValueSize})
+	assert.Error(t, err, "expected error when the value length exceeds the configured length")
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoom, map[string]string{fixtureExceedKeySizeInternal: "some value"})
+	assert.NoError(t, err, "expected no error when the key length exceeds the configured length for a internal key")
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoom, map[string]string{fixtureExceedKeySizeInternal: fixtureExceedValueSize})
+	assert.NoError(t, err, "expected no error when the value length exceeds the configured length for a internal key")
+
+	// tests for a combination of both internal an non internal labels
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoom, fixtureLabelsCombinationNew)
+	assert.NoError(t, err, "expected to be able to add a combination of new internal and non internal labels in a map that has room")
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoomWithInternal, fixtureLabelsCombinationNew)
+	assert.NoError(t, err, "expected to be able to add a combination of new internal and non internal labels in a map that has room (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureExactLabels, fixtureLabelsCombinationNew)
+	assert.Error(t, err, "expected error when adding a combination of new internal and non internal labels in a map that is at capacity")
+
+	err = fixtureLabelOptions.validateLabels(fixtureExactLabelsWithInternal, fixtureLabelsCombinationNew)
+	assert.Error(t, err, "expected error when adding a combination of new internal and non internal labels in a map that is at capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureTooBigLabels, fixtureLabelsCombinationNew)
+	assert.Error(t, err, "expected error when adding a combination of new internal and non internal labels in a map that is at over capacity")
+
+	err = fixtureLabelOptions.validateLabels(fixtureTooBigLabelsWithInternal, fixtureLabelsCombinationNew)
+	assert.Error(t, err, "expected error when adding a combination of new internal and non internal labels in a map that is at over capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoom, fixtureLabelsCombinationOverwrite)
+	assert.NoError(t, err, "expected to be able to add a combination of existing internal and non internal labels in a map that has room")
+
+	err = fixtureLabelOptions.validateLabels(fixtureLabelsRoomWithInternal, fixtureLabelsCombinationOverwrite)
+	assert.NoError(t, err, "expected to be able to add a combination of existing internal and non internal labels in a map that has room (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureExactLabels, fixtureLabelsCombinationOverwrite)
+	assert.NoError(t, err, "expected to be able to add a combination of existing internal and non internal labels in a map that is at capacity")
+
+	err = fixtureLabelOptions.validateLabels(fixtureExactLabelsWithInternal, fixtureLabelsCombinationOverwrite)
+	assert.NoError(t, err, "expected to be able to add a combination of existing internal and non internal labels in a map that is at capacity (with internal)")
+
+	err = fixtureLabelOptions.validateLabels(fixtureTooBigLabels, fixtureLabelsCombinationOverwrite)
+	assert.NoError(t, err, "expected to be able to add a combination of existing internal and non internal labels in a map that is at over capacity")
+
+	err = fixtureLabelOptions.validateLabels(fixtureTooBigLabelsWithInternal, fixtureLabelsCombinationOverwrite)
+	assert.NoError(t, err, "expected to be able to add a combination of existing internal and non internal labels in a map that is at over capacity (with internal)")
 }
 
 var countingLabelsTests = []struct {

--- a/swim/node.go
+++ b/swim/node.go
@@ -66,6 +66,8 @@ type Options struct {
 	PartitionHealPeriod           time.Duration
 	PartitionHealBaseProbabillity float64
 
+	LabelLimits LabelOptions
+
 	Clock clock.Clock
 }
 
@@ -91,6 +93,8 @@ func defaultOptions() *Options {
 		PartitionHealPeriod:           30 * time.Second,
 		PartitionHealBaseProbabillity: 3,
 
+		LabelLimits: DefaultLabelOptions,
+
 		Clock: clock.New(),
 
 		MaxReverseFullSyncJobs: 5,
@@ -107,6 +111,7 @@ func mergeDefaultOptions(opts *Options) *Options {
 	}
 
 	opts.StateTimeouts = mergeStateTimeouts(opts.StateTimeouts, def.StateTimeouts)
+	opts.LabelLimits = mergeLabelOptions(opts.LabelLimits, def.LabelLimits)
 
 	opts.MinProtocolPeriod = util.SelectDuration(opts.MinProtocolPeriod, def.MinProtocolPeriod)
 
@@ -186,6 +191,8 @@ type Node struct {
 
 	logger log.Logger
 
+	labelLimits LabelOptions
+
 	// clock is used to generate incarnation numbers; it is typically the
 	// system clock, wrapped via clock.New()
 	clock clock.Clock
@@ -215,6 +222,8 @@ func NewNode(app, address string, channel shared.SubChannel, opts *Options) *Nod
 		totalRate:  metrics.NewMeter(),
 		clock:      opts.Clock,
 	}
+
+	node.labelLimits = opts.LabelLimits
 
 	node.memberlist = newMemberlist(node)
 	node.memberiter = newMemberlistIter(node.memberlist)


### PR DESCRIPTION
Since labels are gossiped around for all members it can cause gossip bloat when used irresponsibly. This will add enforceable limits on labels to prevent the such bloat from happening. Labels will be ignored when the application tries to set a label or multiple labels that would violate the allowed budget for the labels.