### PR TITLE
[Labels] Prevent checksum collisions for labels

### DIFF
--- a/swim/labels.go
+++ b/swim/labels.go
@@ -1,5 +1,48 @@
 package swim
 
+import (
+	"errors"
+	"strings"
+)
+
+var (
+	// labelsBannedKeyCharacters keeps a list of all banned occurances for label keys
+	labelsBannedKeyCharacters = []string{
+		// the equal sign is used in label checksum calculation. To prevent
+		// unintended or forced collisions on the checksums of labels we do not
+		// allow the equal sign to be used in the key portion of a label
+		"=",
+	}
+
+	// ErrLabelInvalidKey is an error that indicates that a key contains a
+	// sequence of characters that are not allowed.
+	ErrLabelInvalidKey = errors.New("the label key contains an unallowed sequence of characters")
+)
+
+// validateLabel validates if the values of both the key and the value are
+// allowed to be gossiped around. Preventing the use of characters that have
+// special meaning in swim.
+func validateLabel(key, value string) error {
+	for _, banned := range labelsBannedKeyCharacters {
+		if strings.Contains(key, banned) {
+			return ErrLabelInvalidKey
+		}
+	}
+	return nil
+}
+
+// validateLabels validates if the values for multiple labels, both the key and
+// the value are allowed to be gossiped around. Preventing the use of characters
+// that have special meaning in swim.
+func validateLabels(labels map[string]string) error {
+	for key, value := range labels {
+		if err := validateLabel(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // NodeLabels implements the ringpop.Labels interface and proxies the calls to
 // the swim.Node backing the membership protocol.
 type NodeLabels struct {

--- a/swim/labels_test.go
+++ b/swim/labels_test.go
@@ -1,0 +1,27 @@
+package swim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var validateLabelTests = []struct {
+	key   string
+	value string
+	err   error
+}{
+	{"hello", "world", nil},
+	{"hello", "world=", nil},
+	{"hello", "wor=ld", nil},
+	{"hello", "=world", nil},
+	{"hello=", "world", ErrLabelInvalidKey},
+	{"hel=lo", "world", ErrLabelInvalidKey},
+	{"=hello", "world", ErrLabelInvalidKey},
+}
+
+func TestValidateLabel(t *testing.T) {
+	for _, test := range validateLabelTests {
+		assert.Equal(t, test.err, validateLabel(test.key, test.value), "key: %q value: %q expected: %+v", test.key, test.value, test.err)
+	}
+}

--- a/swim/labels_test.go
+++ b/swim/labels_test.go
@@ -25,3 +25,26 @@ func TestValidateLabel(t *testing.T) {
 		assert.Equal(t, test.err, validateLabel(test.key, test.value), "key: %q value: %q expected: %+v", test.key, test.value, test.err)
 	}
 }
+
+var validateLabelsTests = []struct {
+	labels map[string]string
+	err    error
+}{
+	{map[string]string{"hello": "world"}, nil},
+	{map[string]string{"hello": "world="}, nil},
+	{map[string]string{"hello": "wor=ld"}, nil},
+	{map[string]string{"hello": "=world"}, nil},
+	{map[string]string{"hello=": "world"}, ErrLabelInvalidKey},
+	{map[string]string{"hel=lo": "world"}, ErrLabelInvalidKey},
+	{map[string]string{"=hello": "world"}, ErrLabelInvalidKey},
+
+	{map[string]string{"foo": "bar", "hello=": "world"}, ErrLabelInvalidKey},
+	{map[string]string{"foo": "bar", "hel=lo": "world"}, ErrLabelInvalidKey},
+	{map[string]string{"foo": "bar", "=hello": "world"}, ErrLabelInvalidKey},
+}
+
+func TestValidateLabels(t *testing.T) {
+	for _, test := range validateLabelsTests {
+		assert.Equal(t, test.err, validateLabels(test.labels), "labels: %v expected: %+v", test.labels, test.err)
+	}
+}

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -285,6 +285,12 @@ func (m *memberlist) SetLocalStatus(status string) {
 }
 
 func (m *memberlist) SetLocalLabel(key, value string) error {
+	// make sure that the contents of the key and value are allowed to be used
+	// in the gossip protocol.
+	if err := validateLabel(key, value); err != nil {
+		return err
+	}
+
 	// TODO implement a sane limit for the size of the labels to prevent users
 	// from impacting the performance of the gossip protocol.
 
@@ -339,6 +345,12 @@ func (m *memberlist) LocalLabelsAsMap() map[string]string {
 // remain in the labels of this node. The operation is guaranteed to succeed
 // completely or not at all.
 func (m *memberlist) SetLocalLabels(labels map[string]string) error {
+	// make sure that the contents of the key and value are allowed to be used
+	// in the gossip protocol.
+	if err := validateLabels(labels); err != nil {
+		return err
+	}
+
 	// ensure that there is a labels map
 	if m.local.Labels == nil {
 		m.local.Labels = make(map[string]string, len(labels))


### PR DESCRIPTION
This PR hardens the checksumming algorithm behind labels by preventing the easy forging of checksum collisions. The labels checksum is calculated by `hash(key + "=" + value)`. By disallowing applications to use the `=` in their keys it is non-trivial to create a hash collision.

Since the hashes are xorred for order independence having the same hash twice effectively negates a certain value in the checksum.