### PR TITLE
use ringpop-common master again for integration tests.

### DIFF
--- a/test/lib.sh
+++ b/test/lib.sh
@@ -2,7 +2,7 @@
 
 declare project_root="${0%/*}/.."
 declare ringpop_common_dir="${0%/*}/ringpop-common"
-declare ringpop_common_branch="feature/labels"
+declare ringpop_common_branch="master"
 
 #
 # Clones or updates the ringpop-common repository.


### PR DESCRIPTION
reset the ringpop-common branch for integration tests back to `master` after it has been wrongfully set to an other branch