### PR TITLE
Travis: consolidate matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 
 env:
   - RUN="make lint"
-  - RUN="make test-unit"
+  - RUN="make test-unit coveralls"
   - RUN="make test-integration"
   - RUN="make test-race"
   - RUN="make test-examples"
@@ -36,9 +36,6 @@ matrix:
 
 script:
   - test/travis
-
-after_success:
-  - test/update-coveralls
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,9 @@ install:
   - make setup
 
 env:
-  - RUN="make lint"
-  - RUN="make test-unit coveralls"
+  - RUN="make test-unit test-examples lint coveralls"
   - RUN="make test-integration"
   - RUN="make test-race"
-  - RUN="make test-examples"
 
 matrix:
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-mocks testpop lint mocks out setup test test-integration test-unit test-race
+.PHONY: clean clean-mocks coveralls testpop lint mocks out setup test test-integration test-unit test-race
 
 SHELL = /bin/bash
 
@@ -27,6 +27,9 @@ clean:
 clean-mocks:
 	rm -f test/mocks/*.go forward/mock_*.go
 	rm -rf test/thrift/pingpong/
+
+coveralls:
+	test/update-coveralls
 
 lint:
 	@:>lint.log


### PR DESCRIPTION
Travis jobs take longer and longer to run because of our matrix size. And secondly coveralls spams a lot not with a matrix of 15 runs (eg. 15 coveralls updates on the same code).

This fix consolidates the following runs into 1 and report coveralls after it:
- test-unit
- test-examples
- lint

Since the setup time of a test is in the order of 3 minutes it doesn't add much time and actually reduces over runtime of the tests by running these 4 things at once. They are also all quite stable so it is not expected to add extra retries.