### PR TITLE
[Travis] Remove go1.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ install:
   - make setup
 
 env:
-  - RUN="make test-unit test-examples lint coveralls"
+  - RUN="make test-unit test-race test-examples lint coveralls"
   - RUN="make test-integration"
-  - RUN="make test-race"
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 go:
   - 1.7
   - 1.6
-  - 1.5
 
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ mocks:
 	test/gen-testfiles
 
 dev_deps:
-	go get github.com/uber/tchannel-go/thrift/thrift-gen
-	./scripts/go-get-version.sh github.com/golang/lint/golint/.../@c6242afa
+	go get -u github.com/uber/tchannel-go/thrift/thrift-gen
+	go get -u github.com/golang/lint/golint/...
 	./scripts/go-get-version.sh github.com/vektra/mockery/.../@130a05e
 
 setup: dev_deps


### PR DESCRIPTION
To improve speed on travis we will remove go1.5. This allows us to go back to the head of golint which dropped go1.5 support a while ago.

To speed up even further we consolidate the matrix and run test-race during our normal tests. It was kept separate in case the race tests were flappy after fixing the race condition, but has been proven stable. No need to run separately anymore.