### PR TITLE
[Feature] Identity carry over part 1 / RBTree abstraction

### DIFF
--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -45,6 +45,12 @@ type Configuration struct {
 	ReplicaPoints int
 }
 
+type replicapoint int
+
+func (me replicapoint) Compare(other interface{}) int {
+	return int(me) - int(other.(replicapoint))
+}
+
 // HashRing stores strings on a consistent hash ring. HashRing internally uses
 // a Red-Black Tree to achieve O(log N) lookup and insertion time.
 type HashRing struct {
@@ -137,7 +143,7 @@ func (r *HashRing) addReplicasNoLock(server string) {
 	r.serverSet[server] = struct{}{}
 	for i := 0; i < r.replicaPoints; i++ {
 		address := fmt.Sprintf("%s%v", server, i)
-		r.tree.Insert(r.hashfunc(address), server)
+		r.tree.Insert(replicapoint(r.hashfunc(address)), server)
 	}
 }
 
@@ -171,7 +177,7 @@ func (r *HashRing) removeReplicasNoLock(server string) {
 	delete(r.serverSet, server)
 	for i := 0; i < r.replicaPoints; i++ {
 		address := fmt.Sprintf("%s%v", server, i)
-		r.tree.Delete(r.hashfunc(address))
+		r.tree.Delete(replicapoint(r.hashfunc(address)))
 	}
 }
 
@@ -276,9 +282,9 @@ func (r *HashRing) lookupNNoLock(key string, n int) []string {
 	// collected all the servers we want, we have reached the
 	// end of the red-black tree and we need to loop around and inspect the
 	// tree starting at 0.
-	r.tree.LookupNUniqueAt(n, hash, unique)
+	r.tree.LookupNUniqueAt(n, replicapoint(hash), unique)
 	if len(unique) < n {
-		r.tree.LookupNUniqueAt(n, 0, unique)
+		r.tree.LookupNUniqueAt(n, replicapoint(0), unique)
 	}
 
 	var servers []string

--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -276,7 +276,7 @@ func (r *HashRing) lookupNNoLock(key string, n int) []string {
 	}
 
 	hash := r.hashfunc(key)
-	unique := make(map[string]struct{})
+	unique := make(map[valuetype]struct{})
 
 	// lookup N unique servers from the red-black tree. If we have not
 	// collected all the servers we want, we have reached the
@@ -289,7 +289,7 @@ func (r *HashRing) lookupNNoLock(key string, n int) []string {
 
 	var servers []string
 	for server := range unique {
-		servers = append(servers, server)
+		servers = append(servers, server.(string))
 	}
 	return servers
 }

--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -47,8 +47,8 @@ type Configuration struct {
 
 type replicapoint int
 
-func (me replicapoint) Compare(other interface{}) int {
-	return int(me) - int(other.(replicapoint))
+func (r replicapoint) Compare(other interface{}) int {
+	return int(r) - int(other.(replicapoint))
 }
 
 // HashRing stores strings on a consistent hash ring. HashRing internally uses

--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -45,10 +45,10 @@ type Configuration struct {
 	ReplicaPoints int
 }
 
-type replicapoint int
+type replicaPoint int
 
-func (r replicapoint) Compare(other interface{}) int {
-	return int(r) - int(other.(replicapoint))
+func (r replicaPoint) Compare(other interface{}) int {
+	return int(r) - int(other.(replicaPoint))
 }
 
 // HashRing stores strings on a consistent hash ring. HashRing internally uses
@@ -143,7 +143,7 @@ func (r *HashRing) addReplicasNoLock(server string) {
 	r.serverSet[server] = struct{}{}
 	for i := 0; i < r.replicaPoints; i++ {
 		address := fmt.Sprintf("%s%v", server, i)
-		r.tree.Insert(replicapoint(r.hashfunc(address)), server)
+		r.tree.Insert(replicaPoint(r.hashfunc(address)), server)
 	}
 }
 
@@ -177,7 +177,7 @@ func (r *HashRing) removeReplicasNoLock(server string) {
 	delete(r.serverSet, server)
 	for i := 0; i < r.replicaPoints; i++ {
 		address := fmt.Sprintf("%s%v", server, i)
-		r.tree.Delete(replicapoint(r.hashfunc(address)))
+		r.tree.Delete(replicaPoint(r.hashfunc(address)))
 	}
 }
 
@@ -282,9 +282,9 @@ func (r *HashRing) lookupNNoLock(key string, n int) []string {
 	// collected all the servers we want, we have reached the
 	// end of the red-black tree and we need to loop around and inspect the
 	// tree starting at 0.
-	r.tree.LookupNUniqueAt(n, replicapoint(hash), unique)
+	r.tree.LookupNUniqueAt(n, replicaPoint(hash), unique)
 	if len(unique) < n {
-		r.tree.LookupNUniqueAt(n, replicapoint(0), unique)
+		r.tree.LookupNUniqueAt(n, replicaPoint(0), unique)
 	}
 
 	var servers []string

--- a/hashring/hashring_test.go
+++ b/hashring/hashring_test.go
@@ -268,9 +268,9 @@ func TestLookupNLoopAround(t *testing.T) {
 	addresses := genAddresses(1, 1, 10)
 	ring.AddRemoveServers(addresses, nil)
 
-	unique := make(map[string]struct{})
+	unique := make(map[valuetype]struct{})
 	ring.tree.LookupNUniqueAt(1, replicapoint(0), unique)
-	var firstInTree string
+	var firstInTree valuetype
 	for server := range unique {
 		firstInTree = server
 		break

--- a/hashring/hashring_test.go
+++ b/hashring/hashring_test.go
@@ -269,7 +269,7 @@ func TestLookupNLoopAround(t *testing.T) {
 	ring.AddRemoveServers(addresses, nil)
 
 	unique := make(map[valuetype]struct{})
-	ring.tree.LookupNUniqueAt(1, replicapoint(0), unique)
+	ring.tree.LookupNUniqueAt(1, replicaPoint(0), unique)
 	var firstInTree valuetype
 	for server := range unique {
 		firstInTree = server

--- a/hashring/hashring_test.go
+++ b/hashring/hashring_test.go
@@ -269,7 +269,7 @@ func TestLookupNLoopAround(t *testing.T) {
 	ring.AddRemoveServers(addresses, nil)
 
 	unique := make(map[string]struct{})
-	ring.tree.LookupNUniqueAt(1, 0, unique)
+	ring.tree.LookupNUniqueAt(1, replicapoint(0), unique)
 	var firstInTree string
 	for server := range unique {
 		firstInTree = server

--- a/hashring/rbtree.go
+++ b/hashring/rbtree.go
@@ -261,6 +261,40 @@ func (n *redBlackNode) search(key keytype) (valuetype, bool) {
 	return "", false
 }
 
+// walk walks the tree in sorted order calling the walking verion on everynode.
+// If the walker function should return wether or not the walk should continue,
+// eg. the first time walker returns false the walk function will exit and no
+// more calls to walker will be made. Since the walk is recursive the walk will
+// respond wether or not the walking has been exited prematurely, eg false is a
+// premature exit, true means natural exit
+func (n *redBlackNode) walk(walker func(*redBlackNode) bool) bool {
+	if n == nil {
+		// the end of the tree does not signal the end of walking, but we can't
+		// walk this node (nil) nor left or right anymore
+		return true
+	}
+
+	// walk left first
+	if !n.left.walk(walker) {
+		// stop if walker indicated to not continue
+		return false
+	}
+	// now visit this node
+	if !walker(n) {
+		// stop if walker indicated to not continue
+		return false
+	}
+	// lastly visit right
+	if !n.right.walk(walker) {
+		// stop if walker indicated to not continue
+		return false
+	}
+
+	// signal that we reached the end and walking should continue till we hit
+	// end of tree
+	return true
+}
+
 // Search searches for a value in the redBlackTree, returns the string and true
 // if found or the empty string and false if val is not in the tree.
 func (t *redBlackTree) Search(key keytype) (valuetype, bool) {

--- a/hashring/rbtree.go
+++ b/hashring/rbtree.go
@@ -30,10 +30,12 @@ type keytype interface {
 	Compare(other interface{}) int
 }
 
+type valuetype interface{}
+
 // redBlackNode is a node of the redBlackTree
 type redBlackNode struct {
 	key   keytype
-	str   string
+	value valuetype
 	left  *redBlackNode
 	right *redBlackNode
 	red   bool
@@ -84,9 +86,12 @@ func doubleRotate(root *redBlackNode, dir bool) *redBlackNode {
 
 // Insert inserts a value and string into the tree
 // Returns true on succesful insertion, false if duplicate exists
-func (t *redBlackTree) Insert(key keytype, str string) (ret bool) {
+func (t *redBlackTree) Insert(key keytype, value valuetype) (ret bool) {
 	if t.root == nil {
-		t.root = &redBlackNode{key: key, str: str}
+		t.root = &redBlackNode{
+			key:   key,
+			value: value,
+		}
 		ret = true
 	} else {
 		var head = &redBlackNode{}
@@ -104,7 +109,11 @@ func (t *redBlackTree) Insert(key keytype, str string) (ret bool) {
 		for {
 			if node == nil {
 				// insert new node at bottom
-				node = &redBlackNode{key: key, str: str, red: true}
+				node = &redBlackNode{
+					key:   key,
+					value: value,
+					red:   true,
+				}
 				parent.setChild(dir, node)
 				ret = true
 			} else if isRed(node.left) && isRed(node.right) {
@@ -225,7 +234,7 @@ func (t *redBlackTree) Delete(key keytype) bool {
 	// get rid of node if we've found one
 	if found != nil {
 		found.key = node.key
-		found.str = node.str
+		found.value = node.value
 		parent.setChild(parent.right == node, node.Child(node.left == nil))
 		t.size--
 	}
@@ -238,10 +247,10 @@ func (t *redBlackTree) Delete(key keytype) bool {
 	return found != nil
 }
 
-func (n *redBlackNode) search(key keytype) (string, bool) {
+func (n *redBlackNode) search(key keytype) (valuetype, bool) {
 	cmp := n.key.Compare(key)
 	if cmp == 0 {
-		return n.str, true
+		return n.value, true
 	} else if 0 < cmp {
 		if n.left != nil {
 			return n.left.search(key)
@@ -254,7 +263,7 @@ func (n *redBlackNode) search(key keytype) (string, bool) {
 
 // Search searches for a value in the redBlackTree, returns the string and true
 // if found or the empty string and false if val is not in the tree.
-func (t *redBlackTree) Search(key keytype) (string, bool) {
+func (t *redBlackTree) Search(key keytype) (valuetype, bool) {
 	if t.root == nil {
 		return "", false
 	}
@@ -264,13 +273,13 @@ func (t *redBlackTree) Search(key keytype) (string, bool) {
 // LookupNAt iterates through the tree from the node with value val, and
 // returns the next n unique strings. This function is not guaranteed to
 // return n strings.
-func (t *redBlackTree) LookupNUniqueAt(n int, key keytype, result map[string]struct{}) {
+func (t *redBlackTree) LookupNUniqueAt(n int, key keytype, result map[valuetype]struct{}) {
 	findNUniqueAbove(t.root, n, key, result)
 }
 
 // findNUniqueAbove is a recursive search that finds n unique strings
 // with a value bigger or equal than val
-func findNUniqueAbove(node *redBlackNode, n int, key keytype, result map[string]struct{}) {
+func findNUniqueAbove(node *redBlackNode, n int, key keytype, result map[valuetype]struct{}) {
 	if len(result) >= n || node == nil {
 		return
 	}
@@ -287,7 +296,7 @@ func findNUniqueAbove(node *redBlackNode, n int, key keytype, result map[string]
 	}
 
 	if cmp >= 0 {
-		result[node.str] = struct{}{}
+		result[node.value] = struct{}{}
 	}
 
 	findNUniqueAbove(node.right, n, key, result)

--- a/hashring/rbtree.go
+++ b/hashring/rbtree.go
@@ -261,10 +261,10 @@ func (n *redBlackNode) search(key keytype) (valuetype, bool) {
 	return nil, false
 }
 
-// walk Walks the tree in sorted order invoking `walker` for each node. If the
-// walker function returns `false`, walking is stopped and no more nodes will be
+// traverseUntil traverses the nodes in the tree in-order invoking `traverse` for each node. If the
+// traverse function returns `false`, traversal is stopped and no more nodes will be
 // visited. Returns `true` if all nodes are visited; `false` if not.
-func (n *redBlackNode) walk(walker func(*redBlackNode) bool) bool {
+func (n *redBlackNode) traverseUntil(traverse func(*redBlackNode) bool) bool {
 	if n == nil {
 		// the end of the tree does not signal the end of walking, but we can't
 		// walk this node (nil) nor left or right anymore
@@ -272,17 +272,17 @@ func (n *redBlackNode) walk(walker func(*redBlackNode) bool) bool {
 	}
 
 	// walk left first
-	if !n.left.walk(walker) {
+	if !n.left.traverseUntil(traverse) {
 		// stop if walker indicated to break
 		return false
 	}
 	// now visit this node
-	if !walker(n) {
+	if !traverse(n) {
 		// stop if walker indicated to break
 		return false
 	}
 	// lastly visit right
-	if !n.right.walk(walker) {
+	if !n.right.traverseUntil(traverse) {
 		// stop if walker indicated to break
 		return false
 	}

--- a/hashring/rbtree.go
+++ b/hashring/rbtree.go
@@ -261,10 +261,10 @@ func (n *redBlackNode) search(key keytype) (valuetype, bool) {
 	return nil, false
 }
 
-// traverseUntil traverses the nodes in the tree in-order invoking `traverse` for each node. If the
-// traverse function returns `false`, traversal is stopped and no more nodes will be
+// traverseWhile traverses the nodes in the tree in-order invoking the `condition`-function argument for each node.
+// If the condition-function returns `false` traversal is stopped and no more nodes will be
 // visited. Returns `true` if all nodes are visited; `false` if not.
-func (n *redBlackNode) traverseUntil(traverse func(*redBlackNode) bool) bool {
+func (n *redBlackNode) traverseWhile(condition func(*redBlackNode) bool) bool {
 	if n == nil {
 		// the end of the tree does not signal the end of walking, but we can't
 		// walk this node (nil) nor left or right anymore
@@ -272,17 +272,17 @@ func (n *redBlackNode) traverseUntil(traverse func(*redBlackNode) bool) bool {
 	}
 
 	// walk left first
-	if !n.left.traverseUntil(traverse) {
+	if !n.left.traverseWhile(condition) {
 		// stop if walker indicated to break
 		return false
 	}
 	// now visit this node
-	if !traverse(n) {
+	if !condition(n) {
 		// stop if walker indicated to break
 		return false
 	}
 	// lastly visit right
-	if !n.right.traverseUntil(traverse) {
+	if !n.right.traverseWhile(condition) {
 		// stop if walker indicated to break
 		return false
 	}

--- a/hashring/rbtree.go
+++ b/hashring/rbtree.go
@@ -301,15 +301,15 @@ func (t *redBlackTree) Search(key keytype) (valuetype, bool) {
 	return t.root.search(key)
 }
 
-// LookupNUniqueAt iterates through the tree from the node last node that is
-// smaller than key, and returns the next n unique values. This function is not
+// LookupNUniqueAt iterates through the tree from the last node that is smaller
+// than key or equal, and returns the next n unique values. This function is not
 // guaranteed to return n values, less might be returned
 func (t *redBlackTree) LookupNUniqueAt(n int, key keytype, result map[valuetype]struct{}) {
 	findNUniqueAbove(t.root, n, key, result)
 }
 
-// findNUniqueAbove is a recursive search that finds n unique values
-// with a value bigger or equal than key
+// findNUniqueAbove is a recursive search that finds n unique values with a key
+// bigger or equal than key
 func findNUniqueAbove(node *redBlackNode, n int, key keytype, result map[valuetype]struct{}) {
 	if len(result) >= n || node == nil {
 		return

--- a/hashring/rbtree.go
+++ b/hashring/rbtree.go
@@ -165,8 +165,8 @@ func (t *redBlackTree) Insert(key keytype, value valuetype) (ret bool) {
 	return ret
 }
 
-// Delete removes a value from the redBlackTree
-// Returns true on succesful deletion, false if val is not in tree
+// Delete removes the entry for key from the redBlackTree. Returns true on
+// succesful deletion, false if the key is not in tree
 func (t *redBlackTree) Delete(key keytype) bool {
 	if t.root == nil {
 		return false
@@ -258,15 +258,12 @@ func (n *redBlackNode) search(key keytype) (valuetype, bool) {
 	} else if n.right != nil {
 		return n.right.search(key)
 	}
-	return "", false
+	return nil, false
 }
 
-// walk walks the tree in sorted order calling the walking verion on everynode.
-// If the walker function should return wether or not the walk should continue,
-// eg. the first time walker returns false the walk function will exit and no
-// more calls to walker will be made. Since the walk is recursive the walk will
-// respond wether or not the walking has been exited prematurely, eg false is a
-// premature exit, true means natural exit
+// walk Walks the tree in sorted order invoking `walker` for each node. If the
+// walker function returns `false`, walking is stopped and no more nodes will be
+// visited. Returns `true` if all nodes are visited; `false` if not.
 func (n *redBlackNode) walk(walker func(*redBlackNode) bool) bool {
 	if n == nil {
 		// the end of the tree does not signal the end of walking, but we can't
@@ -276,17 +273,17 @@ func (n *redBlackNode) walk(walker func(*redBlackNode) bool) bool {
 
 	// walk left first
 	if !n.left.walk(walker) {
-		// stop if walker indicated to not continue
+		// stop if walker indicated to break
 		return false
 	}
 	// now visit this node
 	if !walker(n) {
-		// stop if walker indicated to not continue
+		// stop if walker indicated to break
 		return false
 	}
 	// lastly visit right
 	if !n.right.walk(walker) {
-		// stop if walker indicated to not continue
+		// stop if walker indicated to break
 		return false
 	}
 
@@ -295,36 +292,36 @@ func (n *redBlackNode) walk(walker func(*redBlackNode) bool) bool {
 	return true
 }
 
-// Search searches for a value in the redBlackTree, returns the string and true
-// if found or the empty string and false if val is not in the tree.
+// Search searches for the entry for key in the redBlackTree, returns the value
+// and true if found or nil and false if there is no entry for key in the tree.
 func (t *redBlackTree) Search(key keytype) (valuetype, bool) {
 	if t.root == nil {
-		return "", false
+		return nil, false
 	}
 	return t.root.search(key)
 }
 
-// LookupNAt iterates through the tree from the node with value val, and
-// returns the next n unique strings. This function is not guaranteed to
-// return n strings.
+// LookupNUniqueAt iterates through the tree from the node last node that is
+// smaller than key, and returns the next n unique values. This function is not
+// guaranteed to return n values, less might be returned
 func (t *redBlackTree) LookupNUniqueAt(n int, key keytype, result map[valuetype]struct{}) {
 	findNUniqueAbove(t.root, n, key, result)
 }
 
-// findNUniqueAbove is a recursive search that finds n unique strings
-// with a value bigger or equal than val
+// findNUniqueAbove is a recursive search that finds n unique values
+// with a value bigger or equal than key
 func findNUniqueAbove(node *redBlackNode, n int, key keytype, result map[valuetype]struct{}) {
 	if len(result) >= n || node == nil {
 		return
 	}
 
-	// skip left branch when all its values are smaller than val
+	// skip left branch when all its keys are smaller than key
 	cmp := node.key.Compare(key)
 	if cmp >= 0 {
 		findNUniqueAbove(node.left, n, key, result)
 	}
 
-	// Make sure to stop when we have n unique strings
+	// Make sure to stop when we have n unique values
 	if len(result) >= n {
 		return
 	}

--- a/hashring/rbtree_test.go
+++ b/hashring/rbtree_test.go
@@ -637,6 +637,53 @@ func TestBig(t *testing.T) {
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
 }
 
+func TestWalkInOrder(t *testing.T) {
+	tree := makeTree()
+
+	//               4,B
+	//             /     \
+	//         2,R         6,R
+	//       /     \     /     \
+	//     1,B    3,B   5,B    7,B
+	//                             \
+	//                              8,R
+
+	var last keytype
+
+	tree.root.walk(func(n *redBlackNode) bool {
+		current := n.key
+		if last != nil {
+			assert.True(t, current.Compare(last) > 0, "expected walk to walk the nodes in natural order as dictated by the Compare function")
+		}
+		last = current
+		return true
+	})
+}
+
+func TestWalkEscape(t *testing.T) {
+	tree := makeTree()
+
+	//               4,B
+	//             /     \
+	//         2,R         6,R
+	//       /     \     /     \
+	//     1,B    3,B   5,B    7,B
+	//                             \
+	//                              8,R
+
+	var visited []int
+
+	tree.root.walk(func(n *redBlackNode) bool {
+		number := int(n.key.(treeTestInt))
+		visited = append(visited, number)
+		// stop at node 5, it should exit on a left, right and visiting node,
+		// this covers all exit cases
+		return number < 5
+	})
+
+	assert.Equal(t, []int{1, 2, 3, 4, 5}, visited, "expected all nodes up to five to be visited")
+}
+
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 //
 // BENCHMARKS

--- a/hashring/rbtree_test.go
+++ b/hashring/rbtree_test.go
@@ -126,7 +126,7 @@ func TestInsert(t *testing.T) {
 	// 4, B
 	node := tree.root
 	assert.Equal(t, treeTestInt(4), node.key, "expected tree root val to be 4")
-	assert.Equal(t, "four", node.str, "expected tree root str to be 'four'")
+	assert.Equal(t, "four", node.value, "expected tree root str to be 'four'")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
 	assert.NotNil(t, node.right, "expected tree root to have right child")
@@ -134,7 +134,7 @@ func TestInsert(t *testing.T) {
 	// 2,R
 	node = tree.root.left
 	assert.Equal(t, treeTestInt(2), node.key, "got unexpected node val")
-	assert.Equal(t, "two", node.str, "got unexpected node str")
+	assert.Equal(t, "two", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "expected node to have left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -142,7 +142,7 @@ func TestInsert(t *testing.T) {
 	// 1,B
 	node = tree.root.left.left
 	assert.Equal(t, treeTestInt(1), node.key, "got unexpected node val")
-	assert.Equal(t, "one", node.str, "got unexpected node str")
+	assert.Equal(t, "one", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -150,7 +150,7 @@ func TestInsert(t *testing.T) {
 	// 3, B
 	node = tree.root.left.right
 	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node val")
-	assert.Equal(t, "three", node.str, "got unexpected node str")
+	assert.Equal(t, "three", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -158,7 +158,7 @@ func TestInsert(t *testing.T) {
 	// 6, R
 	node = tree.root.right
 	assert.Equal(t, treeTestInt(6), node.key, "got unexpected node val")
-	assert.Equal(t, "six", node.str, "got unexpected node str")
+	assert.Equal(t, "six", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "expected node to have left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -166,7 +166,7 @@ func TestInsert(t *testing.T) {
 	// 5, B
 	node = tree.root.right.left
 	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
-	assert.Equal(t, "five", node.str, "got unexpected node str")
+	assert.Equal(t, "five", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -174,7 +174,7 @@ func TestInsert(t *testing.T) {
 	// 7, B
 	node = tree.root.right.right
 	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.str, "got unexpected node str")
+	assert.Equal(t, "seven", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -182,7 +182,7 @@ func TestInsert(t *testing.T) {
 	// 8, R
 	node = tree.root.right.right.right
 	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.str, "got unexpected node str")
+	assert.Equal(t, "eight", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -266,7 +266,7 @@ func TestDelete(t *testing.T) {
 	// 4,B
 	node := tree.root
 	assert.Equal(t, treeTestInt(4), node.key, "expected tree root val to be 4")
-	assert.Equal(t, "four", node.str, "expected tree root str to be 'four'")
+	assert.Equal(t, "four", node.value, "expected tree root str to be 'four'")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
 	assert.NotNil(t, node.right, "expected tree root to have right child")
@@ -274,7 +274,7 @@ func TestDelete(t *testing.T) {
 	// 2,R
 	node = tree.root.left
 	assert.Equal(t, treeTestInt(2), node.key, "got unexpected node val")
-	assert.Equal(t, "two", node.str, "got unexpected node str")
+	assert.Equal(t, "two", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -282,7 +282,7 @@ func TestDelete(t *testing.T) {
 	// 3,B
 	node = tree.root.left.right
 	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node val")
-	assert.Equal(t, "three", node.str, "got unexpected node str")
+	assert.Equal(t, "three", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -290,7 +290,7 @@ func TestDelete(t *testing.T) {
 	// 6,R
 	node = tree.root.right
 	assert.Equal(t, treeTestInt(6), node.key, "got unexpected node val")
-	assert.Equal(t, "six", node.str, "got unexpected node str")
+	assert.Equal(t, "six", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour.")
 	assert.NotNil(t, node.left, "expected node to have left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -298,7 +298,7 @@ func TestDelete(t *testing.T) {
 	// 5, B
 	node = tree.root.right.left
 	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
-	assert.Equal(t, "five", node.str, "got unexpected node str")
+	assert.Equal(t, "five", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -306,7 +306,7 @@ func TestDelete(t *testing.T) {
 	// 7, B
 	node = tree.root.right.right
 	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.str, "got unexpected node str")
+	assert.Equal(t, "seven", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -314,7 +314,7 @@ func TestDelete(t *testing.T) {
 	// 8, R
 	node = tree.root.right.right.right
 	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.str, "got unexpected node str")
+	assert.Equal(t, "eight", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -336,7 +336,7 @@ func TestDelete(t *testing.T) {
 	// 6,B
 	node = tree.root
 	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
-	assert.Equal(t, "six", node.str, "expected tree root str to be 6")
+	assert.Equal(t, "six", node.value, "expected tree root str to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
 	assert.NotNil(t, node.right, "expected tree root to have right child")
@@ -344,7 +344,7 @@ func TestDelete(t *testing.T) {
 	// 4,R
 	node = tree.root.left
 	assert.Equal(t, treeTestInt(4), node.key, "got unexpected node val")
-	assert.Equal(t, "four", node.str, "got unexpected node str")
+	assert.Equal(t, "four", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "node should have left child")
 	assert.NotNil(t, node.right, "node should have right child")
@@ -352,7 +352,7 @@ func TestDelete(t *testing.T) {
 	// 3,B
 	node = tree.root.left.left
 	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node val")
-	assert.Equal(t, "three", node.str, "got unexpected node str")
+	assert.Equal(t, "three", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -360,7 +360,7 @@ func TestDelete(t *testing.T) {
 	// 5,B
 	node = tree.root.left.right
 	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
-	assert.Equal(t, "five", node.str, "got unexpected node str")
+	assert.Equal(t, "five", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -368,7 +368,7 @@ func TestDelete(t *testing.T) {
 	// 7,B
 	node = tree.root.right
 	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.str, "got unexpected node str")
+	assert.Equal(t, "seven", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -376,7 +376,7 @@ func TestDelete(t *testing.T) {
 	// 8,R
 	node = tree.root.right.right
 	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.str, "got unexpected node str")
+	assert.Equal(t, "eight", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -398,7 +398,7 @@ func TestDelete(t *testing.T) {
 	// 6,B
 	node = tree.root
 	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
-	assert.Equal(t, "six", node.str, "expected tree root str to be 6")
+	assert.Equal(t, "six", node.value, "expected tree root str to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
 	assert.NotNil(t, node.right, "expected tree root to have right child")
@@ -406,7 +406,7 @@ func TestDelete(t *testing.T) {
 	// 4,B
 	node = tree.root.left
 	assert.Equal(t, treeTestInt(4), node.key, "got unexpected node val")
-	assert.Equal(t, "four", node.str, "got unexpected node str")
+	assert.Equal(t, "four", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -414,7 +414,7 @@ func TestDelete(t *testing.T) {
 	// 5,R
 	node = tree.root.left.right
 	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
-	assert.Equal(t, "five", node.str, "got unexpected node str")
+	assert.Equal(t, "five", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -422,7 +422,7 @@ func TestDelete(t *testing.T) {
 	// 7,B
 	node = tree.root.right
 	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.str, "got unexpected node str")
+	assert.Equal(t, "seven", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -430,7 +430,7 @@ func TestDelete(t *testing.T) {
 	// 8,R
 	node = tree.root.right.right
 	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.str, "got unexpected node str")
+	assert.Equal(t, "eight", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -452,7 +452,7 @@ func TestDelete(t *testing.T) {
 	// 6,B
 	node = tree.root
 	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
-	assert.Equal(t, "six", node.str, "expected tree root str to be 6")
+	assert.Equal(t, "six", node.value, "expected tree root str to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
 	assert.NotNil(t, node.right, "expected tree root to have right child")
@@ -460,7 +460,7 @@ func TestDelete(t *testing.T) {
 	// 5,B
 	node = tree.root.left
 	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
-	assert.Equal(t, "five", node.str, "got unexpected node str")
+	assert.Equal(t, "five", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -468,7 +468,7 @@ func TestDelete(t *testing.T) {
 	// 7,B
 	node = tree.root.right
 	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.str, "got unexpected node str")
+	assert.Equal(t, "seven", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -476,7 +476,7 @@ func TestDelete(t *testing.T) {
 	// 8,R
 	node = tree.root.right.right
 	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.str, "got unexpected node str")
+	assert.Equal(t, "eight", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -496,7 +496,7 @@ func TestDelete(t *testing.T) {
 	// 7,B
 	node = tree.root
 	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.str, "got unexpected node str")
+	assert.Equal(t, "seven", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "expected node to have left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -504,7 +504,7 @@ func TestDelete(t *testing.T) {
 	// 6,B
 	node = tree.root.left
 	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
-	assert.Equal(t, "six", node.str, "expected tree root str to be 6")
+	assert.Equal(t, "six", node.value, "expected tree root str to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.Nil(t, node.left, "expected tree root to have left child")
 	assert.Nil(t, node.right, "expected tree root to have right child")
@@ -512,7 +512,7 @@ func TestDelete(t *testing.T) {
 	// 8,R
 	node = tree.root.right
 	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.str, "got unexpected node str")
+	assert.Equal(t, "eight", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -532,7 +532,7 @@ func TestDelete(t *testing.T) {
 	// 7,B
 	node = tree.root
 	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.str, "got unexpected node str")
+	assert.Equal(t, "seven", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
@@ -540,7 +540,7 @@ func TestDelete(t *testing.T) {
 	// 8,R
 	node = tree.root.right
 	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.str, "got unexpected node str")
+	assert.Equal(t, "eight", node.value, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -558,7 +558,7 @@ func TestDelete(t *testing.T) {
 	// 8,B
 	node = tree.root
 	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.str, "got unexpected node str")
+	assert.Equal(t, "eight", node.value, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")

--- a/hashring/rbtree_test.go
+++ b/hashring/rbtree_test.go
@@ -81,7 +81,7 @@ func validateRedBlackTree(n *redBlackNode) (int, error) {
 	var err error
 
 	if isRed(n) && (isRed(n.left) || isRed(n.right)) {
-		err = errors.New(fmt.Sprint("red violation at node val ", n.key))
+		err = errors.New(fmt.Sprint("red violation at node key ", n.key))
 		return 0, err
 	}
 
@@ -96,13 +96,13 @@ func validateRedBlackTree(n *redBlackNode) (int, error) {
 
 	if n.left != nil && n.left.key.Compare(n.key) >= 0 ||
 		n.right != nil && n.right.key.Compare(n.key) <= 0 {
-		err = errors.New(fmt.Sprint("binary tree violation at node val ", n.key))
+		err = errors.New(fmt.Sprint("binary tree violation at node key ", n.key))
 		return 0, err
 	}
 
 	if leftHeight != 0 && rightHeight != 0 {
 		if leftHeight != rightHeight {
-			err = errors.New(fmt.Sprint("black height violation at node val ", n.key))
+			err = errors.New(fmt.Sprint("black height violation at node key ", n.key))
 			return 0, err
 		}
 
@@ -125,75 +125,75 @@ func TestInsert(t *testing.T) {
 
 	// 4, B
 	node := tree.root
-	assert.Equal(t, treeTestInt(4), node.key, "expected tree root val to be 4")
-	assert.Equal(t, "four", node.value, "expected tree root str to be 'four'")
+	assert.Equal(t, treeTestInt(4), node.key, "expected tree root key to be 4")
+	assert.Equal(t, "four", node.value, "expected tree root value to be 'four'")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
 	assert.NotNil(t, node.right, "expected tree root to have right child")
 
 	// 2,R
 	node = tree.root.left
-	assert.Equal(t, treeTestInt(2), node.key, "got unexpected node val")
-	assert.Equal(t, "two", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(2), node.key, "got unexpected node key")
+	assert.Equal(t, "two", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "expected node to have left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 1,B
 	node = tree.root.left.left
-	assert.Equal(t, treeTestInt(1), node.key, "got unexpected node val")
-	assert.Equal(t, "one", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(1), node.key, "got unexpected node key")
+	assert.Equal(t, "one", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// 3, B
 	node = tree.root.left.right
-	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node val")
-	assert.Equal(t, "three", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node key")
+	assert.Equal(t, "three", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// 6, R
 	node = tree.root.right
-	assert.Equal(t, treeTestInt(6), node.key, "got unexpected node val")
-	assert.Equal(t, "six", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(6), node.key, "got unexpected node key")
+	assert.Equal(t, "six", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "expected node to have left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 5, B
 	node = tree.root.right.left
-	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
-	assert.Equal(t, "five", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node key")
+	assert.Equal(t, "five", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// 7, B
 	node = tree.root.right.right
-	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node key")
+	assert.Equal(t, "seven", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 8, R
 	node = tree.root.right.right.right
-	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node key")
+	assert.Equal(t, "eight", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
-	str, found := tree.Search(treeTestInt(7))
-	assert.True(t, found, "expected value to be found in tree")
-	assert.Equal(t, "seven", str, "expected serach return value of 'seven'")
+	value, found := tree.Search(treeTestInt(7))
+	assert.True(t, found, "expected key to be found in tree")
+	assert.Equal(t, "seven", value, "expected search return value of 'seven'")
 
-	str, found = tree.Search(treeTestInt(9))
-	assert.False(t, found, "expected value to not be found in tree")
-	assert.Equal(t, "", str, "expected search to return empty string ''")
+	value, found = tree.Search(treeTestInt(9))
+	assert.False(t, found, "expected key to not be found in tree")
+	assert.Equal(t, nil, value, "expected search to return nil")
 }
 
 func TestDuplicateInsert(t *testing.T) {
@@ -265,56 +265,56 @@ func TestDelete(t *testing.T) {
 
 	// 4,B
 	node := tree.root
-	assert.Equal(t, treeTestInt(4), node.key, "expected tree root val to be 4")
-	assert.Equal(t, "four", node.value, "expected tree root str to be 'four'")
+	assert.Equal(t, treeTestInt(4), node.key, "expected tree root key to be 4")
+	assert.Equal(t, "four", node.value, "expected tree root value to be 'four'")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
 	assert.NotNil(t, node.right, "expected tree root to have right child")
 
 	// 2,R
 	node = tree.root.left
-	assert.Equal(t, treeTestInt(2), node.key, "got unexpected node val")
-	assert.Equal(t, "two", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(2), node.key, "got unexpected node key")
+	assert.Equal(t, "two", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 3,B
 	node = tree.root.left.right
-	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node val")
-	assert.Equal(t, "three", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node key")
+	assert.Equal(t, "three", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// 6,R
 	node = tree.root.right
-	assert.Equal(t, treeTestInt(6), node.key, "got unexpected node val")
-	assert.Equal(t, "six", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(6), node.key, "got unexpected node key")
+	assert.Equal(t, "six", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour.")
 	assert.NotNil(t, node.left, "expected node to have left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 5, B
 	node = tree.root.right.left
-	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
-	assert.Equal(t, "five", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node key")
+	assert.Equal(t, "five", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// 7, B
 	node = tree.root.right.right
-	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node key")
+	assert.Equal(t, "seven", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 8, R
 	node = tree.root.right.right.right
-	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node key")
+	assert.Equal(t, "eight", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -335,48 +335,48 @@ func TestDelete(t *testing.T) {
 
 	// 6,B
 	node = tree.root
-	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
-	assert.Equal(t, "six", node.value, "expected tree root str to be 6")
+	assert.Equal(t, treeTestInt(6), node.key, "expected tree root key to be 6")
+	assert.Equal(t, "six", node.value, "expected tree root value to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
 	assert.NotNil(t, node.right, "expected tree root to have right child")
 
 	// 4,R
 	node = tree.root.left
-	assert.Equal(t, treeTestInt(4), node.key, "got unexpected node val")
-	assert.Equal(t, "four", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(4), node.key, "got unexpected node key")
+	assert.Equal(t, "four", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "node should have left child")
 	assert.NotNil(t, node.right, "node should have right child")
 
 	// 3,B
 	node = tree.root.left.left
-	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node val")
-	assert.Equal(t, "three", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node key")
+	assert.Equal(t, "three", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// 5,B
 	node = tree.root.left.right
-	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
-	assert.Equal(t, "five", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node key")
+	assert.Equal(t, "five", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// 7,B
 	node = tree.root.right
-	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node key")
+	assert.Equal(t, "seven", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 8,R
 	node = tree.root.right.right
-	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node key")
+	assert.Equal(t, "eight", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -397,40 +397,40 @@ func TestDelete(t *testing.T) {
 
 	// 6,B
 	node = tree.root
-	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
-	assert.Equal(t, "six", node.value, "expected tree root str to be 6")
+	assert.Equal(t, treeTestInt(6), node.key, "expected tree root key to be 6")
+	assert.Equal(t, "six", node.value, "expected tree root value to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
 	assert.NotNil(t, node.right, "expected tree root to have right child")
 
 	// 4,B
 	node = tree.root.left
-	assert.Equal(t, treeTestInt(4), node.key, "got unexpected node val")
-	assert.Equal(t, "four", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(4), node.key, "got unexpected node key")
+	assert.Equal(t, "four", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 5,R
 	node = tree.root.left.right
-	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
-	assert.Equal(t, "five", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node key")
+	assert.Equal(t, "five", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// 7,B
 	node = tree.root.right
-	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node key")
+	assert.Equal(t, "seven", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 8,R
 	node = tree.root.right.right
-	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node key")
+	assert.Equal(t, "eight", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -451,32 +451,32 @@ func TestDelete(t *testing.T) {
 
 	// 6,B
 	node = tree.root
-	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
-	assert.Equal(t, "six", node.value, "expected tree root str to be 6")
+	assert.Equal(t, treeTestInt(6), node.key, "expected tree root key to be 6")
+	assert.Equal(t, "six", node.value, "expected tree root value to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
 	assert.NotNil(t, node.right, "expected tree root to have right child")
 
 	// 5,B
 	node = tree.root.left
-	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
-	assert.Equal(t, "five", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node key")
+	assert.Equal(t, "five", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// 7,B
 	node = tree.root.right
-	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node key")
+	assert.Equal(t, "seven", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 8,R
 	node = tree.root.right.right
-	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node key")
+	assert.Equal(t, "eight", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -495,24 +495,24 @@ func TestDelete(t *testing.T) {
 
 	// 7,B
 	node = tree.root
-	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node key")
+	assert.Equal(t, "seven", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "expected node to have left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 6,B
 	node = tree.root.left
-	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
-	assert.Equal(t, "six", node.value, "expected tree root str to be 6")
+	assert.Equal(t, treeTestInt(6), node.key, "expected tree root key to be 6")
+	assert.Equal(t, "six", node.value, "expected tree root value to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.Nil(t, node.left, "expected tree root to have left child")
 	assert.Nil(t, node.right, "expected tree root to have right child")
 
 	// 8,R
 	node = tree.root.right
-	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node key")
+	assert.Equal(t, "eight", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -531,16 +531,16 @@ func TestDelete(t *testing.T) {
 
 	// 7,B
 	node = tree.root
-	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
-	assert.Equal(t, "seven", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node key")
+	assert.Equal(t, "seven", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.NotNil(t, node.right, "expected node to have right child")
 
 	// 8,R
 	node = tree.root.right
-	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node key")
+	assert.Equal(t, "eight", node.value, "got unexpected node value")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -557,8 +557,8 @@ func TestDelete(t *testing.T) {
 
 	// 8,B
 	node = tree.root
-	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
-	assert.Equal(t, "eight", node.value, "got unexpected node str")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node key")
+	assert.Equal(t, "eight", node.value, "got unexpected node value")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
@@ -585,7 +585,7 @@ func TestSearchEmpty(t *testing.T) {
 
 	str, ok := tree.Search(treeTestInt(5))
 	assert.False(t, ok, "expected node to not be found")
-	assert.Equal(t, "", str, "expected str to be empty")
+	assert.Equal(t, nil, str, "expected value to be nil")
 }
 
 func TestSearch(t *testing.T) {
@@ -599,21 +599,21 @@ func TestSearch(t *testing.T) {
 	//                             \
 	//                              8,R
 
-	str, ok := tree.Search(treeTestInt(5))
+	value, ok := tree.Search(treeTestInt(5))
 	assert.True(t, ok, "expected node to be found")
-	assert.Equal(t, "five", str, "expected str to be five")
+	assert.Equal(t, "five", value, "expected value to be 'five'")
 
-	str, ok = tree.Search(treeTestInt(3))
+	value, ok = tree.Search(treeTestInt(3))
 	assert.True(t, ok, "expected node to be found")
-	assert.Equal(t, "three", str, "expected str to be three")
+	assert.Equal(t, "three", value, "expected value to be 'three'")
 
-	str, ok = tree.Search(treeTestInt(8))
+	value, ok = tree.Search(treeTestInt(8))
 	assert.True(t, ok, "expected node to be found")
-	assert.Equal(t, "eight", str, "expected str to be three")
+	assert.Equal(t, "eight", value, "expected value to be 'three'")
 
-	str, ok = tree.Search(treeTestInt(9))
+	value, ok = tree.Search(treeTestInt(9))
 	assert.False(t, ok, "expected node to not be found")
-	assert.Equal(t, "", str, "expected str to be empty")
+	assert.Equal(t, nil, value, "expected value to be nil")
 }
 
 func TestBig(t *testing.T) {

--- a/hashring/rbtree_test.go
+++ b/hashring/rbtree_test.go
@@ -650,7 +650,7 @@ func TestTraverseOrder(t *testing.T) {
 
 	var last keytype
 
-	tree.root.traverseUntil(func(n *redBlackNode) bool {
+	tree.root.traverseWhile(func(n *redBlackNode) bool {
 		current := n.key
 		if last != nil {
 			assert.True(t, current.Compare(last) > 0, "expected walk to walk the nodes in natural order as dictated by the Compare function")
@@ -673,7 +673,7 @@ func TestTraverseEscape(t *testing.T) {
 
 	var visited []int
 
-	tree.root.traverseUntil(func(n *redBlackNode) bool {
+	tree.root.traverseWhile(func(n *redBlackNode) bool {
 		number := int(n.key.(treeTestInt))
 		visited = append(visited, number)
 		// stop at node 5, it should exit on a left, right and visiting node,

--- a/hashring/rbtree_test.go
+++ b/hashring/rbtree_test.go
@@ -637,7 +637,7 @@ func TestBig(t *testing.T) {
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
 }
 
-func TestWalkInOrder(t *testing.T) {
+func TestTraverseOrder(t *testing.T) {
 	tree := makeTree()
 
 	//               4,B
@@ -650,7 +650,7 @@ func TestWalkInOrder(t *testing.T) {
 
 	var last keytype
 
-	tree.root.walk(func(n *redBlackNode) bool {
+	tree.root.traverseUntil(func(n *redBlackNode) bool {
 		current := n.key
 		if last != nil {
 			assert.True(t, current.Compare(last) > 0, "expected walk to walk the nodes in natural order as dictated by the Compare function")
@@ -660,7 +660,7 @@ func TestWalkInOrder(t *testing.T) {
 	})
 }
 
-func TestWalkEscape(t *testing.T) {
+func TestTraverseEscape(t *testing.T) {
 	tree := makeTree()
 
 	//               4,B
@@ -673,7 +673,7 @@ func TestWalkEscape(t *testing.T) {
 
 	var visited []int
 
-	tree.root.walk(func(n *redBlackNode) bool {
+	tree.root.traverseUntil(func(n *redBlackNode) bool {
 		number := int(n.key.(treeTestInt))
 		visited = append(visited, number)
 		// stop at node 5, it should exit on a left, right and visiting node,

--- a/hashring/rbtree_test.go
+++ b/hashring/rbtree_test.go
@@ -30,6 +30,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type treeTestInt int
+
+func (me treeTestInt) Compare(other interface{}) int {
+	return int(me) - int(other.(treeTestInt))
+}
+
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 //
 // TESTS
@@ -39,14 +45,14 @@ import (
 func makeTree() redBlackTree {
 	tree := redBlackTree{}
 
-	tree.Insert(1, "one")
-	tree.Insert(2, "two")
-	tree.Insert(3, "three")
-	tree.Insert(4, "four")
-	tree.Insert(5, "five")
-	tree.Insert(6, "six")
-	tree.Insert(7, "seven")
-	tree.Insert(8, "eight")
+	tree.Insert(treeTestInt(1), "one")
+	tree.Insert(treeTestInt(2), "two")
+	tree.Insert(treeTestInt(3), "three")
+	tree.Insert(treeTestInt(4), "four")
+	tree.Insert(treeTestInt(5), "five")
+	tree.Insert(treeTestInt(6), "six")
+	tree.Insert(treeTestInt(7), "seven")
+	tree.Insert(treeTestInt(8), "eight")
 
 	//               4,B
 	//             /     \
@@ -75,7 +81,7 @@ func validateRedBlackTree(n *redBlackNode) (int, error) {
 	var err error
 
 	if isRed(n) && (isRed(n.left) || isRed(n.right)) {
-		err = errors.New(fmt.Sprint("red violation at node val ", n.val))
+		err = errors.New(fmt.Sprint("red violation at node val ", n.key))
 		return 0, err
 	}
 
@@ -88,15 +94,15 @@ func validateRedBlackTree(n *redBlackNode) (int, error) {
 		return 0, err
 	}
 
-	if n.left != nil && n.left.val >= n.val ||
-		n.right != nil && n.right.val <= n.val {
-		err = errors.New(fmt.Sprint("binary tree violation at node val ", n.val))
+	if n.left != nil && n.left.key.Compare(n.key) >= 0 ||
+		n.right != nil && n.right.key.Compare(n.key) <= 0 {
+		err = errors.New(fmt.Sprint("binary tree violation at node val ", n.key))
 		return 0, err
 	}
 
 	if leftHeight != 0 && rightHeight != 0 {
 		if leftHeight != rightHeight {
-			err = errors.New(fmt.Sprint("black height violation at node val ", n.val))
+			err = errors.New(fmt.Sprint("black height violation at node val ", n.key))
 			return 0, err
 		}
 
@@ -119,7 +125,7 @@ func TestInsert(t *testing.T) {
 
 	// 4, B
 	node := tree.root
-	assert.Equal(t, 4, node.val, "expected tree root val to be 4")
+	assert.Equal(t, treeTestInt(4), node.key, "expected tree root val to be 4")
 	assert.Equal(t, "four", node.str, "expected tree root str to be 'four'")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
@@ -127,7 +133,7 @@ func TestInsert(t *testing.T) {
 
 	// 2,R
 	node = tree.root.left
-	assert.Equal(t, 2, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(2), node.key, "got unexpected node val")
 	assert.Equal(t, "two", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "expected node to have left child")
@@ -135,7 +141,7 @@ func TestInsert(t *testing.T) {
 
 	// 1,B
 	node = tree.root.left.left
-	assert.Equal(t, 1, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(1), node.key, "got unexpected node val")
 	assert.Equal(t, "one", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -143,7 +149,7 @@ func TestInsert(t *testing.T) {
 
 	// 3, B
 	node = tree.root.left.right
-	assert.Equal(t, 3, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node val")
 	assert.Equal(t, "three", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -151,7 +157,7 @@ func TestInsert(t *testing.T) {
 
 	// 6, R
 	node = tree.root.right
-	assert.Equal(t, 6, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(6), node.key, "got unexpected node val")
 	assert.Equal(t, "six", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "expected node to have left child")
@@ -159,7 +165,7 @@ func TestInsert(t *testing.T) {
 
 	// 5, B
 	node = tree.root.right.left
-	assert.Equal(t, 5, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
 	assert.Equal(t, "five", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -167,7 +173,7 @@ func TestInsert(t *testing.T) {
 
 	// 7, B
 	node = tree.root.right.right
-	assert.Equal(t, 7, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
 	assert.Equal(t, "seven", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -175,17 +181,17 @@ func TestInsert(t *testing.T) {
 
 	// 8, R
 	node = tree.root.right.right.right
-	assert.Equal(t, 8, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
 	assert.Equal(t, "eight", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
-	str, found := tree.Search(7)
+	str, found := tree.Search(treeTestInt(7))
 	assert.True(t, found, "expected value to be found in tree")
 	assert.Equal(t, "seven", str, "expected serach return value of 'seven'")
 
-	str, found = tree.Search(9)
+	str, found = tree.Search(treeTestInt(9))
 	assert.False(t, found, "expected value to not be found in tree")
 	assert.Equal(t, "", str, "expected search to return empty string ''")
 }
@@ -195,10 +201,10 @@ func TestDuplicateInsert(t *testing.T) {
 
 	assert.Equal(t, 8, tree.Size(), "expected tree to have 8 nodes")
 
-	assert.True(t, tree.Insert(9, "nine"), "failed, expected insertion success")
+	assert.True(t, tree.Insert(treeTestInt(9), "nine"), "failed, expected insertion success")
 	assert.Equal(t, 9, tree.Size(), "expected tree to have 9 nodes")
 
-	assert.False(t, tree.Insert(1, "one"), "success, expected insertion to fail (duplicate value)")
+	assert.False(t, tree.Insert(treeTestInt(1), "one"), "success, expected insertion to fail (duplicate value)")
 	assert.Equal(t, 9, tree.Size(), "expected tree to have 9 nodes")
 }
 
@@ -207,18 +213,18 @@ func TestRemoveInsert(t *testing.T) {
 
 	assert.Equal(t, 8, tree.Size(), "expected tree to have 8 nodes")
 
-	assert.True(t, tree.Delete(2), "failed, expected successful deletion")
-	assert.True(t, tree.Delete(4), "failed, expected successful deletion")
+	assert.True(t, tree.Delete(treeTestInt(2)), "failed, expected successful deletion")
+	assert.True(t, tree.Delete(treeTestInt(4)), "failed, expected successful deletion")
 
 	assert.Equal(t, 6, tree.Size(), "expected tree to have 6 nodes")
 
-	assert.True(t, tree.Insert(2, "two"), "failed, expected insertions success")
+	assert.True(t, tree.Insert(treeTestInt(2), "two"), "failed, expected insertions success")
 	_, err := validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
 
 	assert.Equal(t, 7, tree.Size(), "expected tree to have 7 nodes")
 
-	assert.True(t, tree.Insert(4, "four"), "failed, expected insertion success")
+	assert.True(t, tree.Insert(treeTestInt(4), "four"), "failed, expected insertion success")
 	_, err = validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
 
@@ -242,7 +248,7 @@ func TestDelete(t *testing.T) {
 	//                              8,R
 
 	// REMOVE 1
-	assert.True(t, tree.Delete(1), "expected node to be found and removed from tree")
+	assert.True(t, tree.Delete(treeTestInt(1)), "expected node to be found and removed from tree")
 	assert.Equal(t, 7, tree.Size(), "expected tree to have 7 nodes")
 	height, err = validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
@@ -259,7 +265,7 @@ func TestDelete(t *testing.T) {
 
 	// 4,B
 	node := tree.root
-	assert.Equal(t, 4, node.val, "expected tree root val to be 4")
+	assert.Equal(t, treeTestInt(4), node.key, "expected tree root val to be 4")
 	assert.Equal(t, "four", node.str, "expected tree root str to be 'four'")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
@@ -267,7 +273,7 @@ func TestDelete(t *testing.T) {
 
 	// 2,R
 	node = tree.root.left
-	assert.Equal(t, 2, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(2), node.key, "got unexpected node val")
 	assert.Equal(t, "two", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -275,7 +281,7 @@ func TestDelete(t *testing.T) {
 
 	// 3,B
 	node = tree.root.left.right
-	assert.Equal(t, 3, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node val")
 	assert.Equal(t, "three", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -283,7 +289,7 @@ func TestDelete(t *testing.T) {
 
 	// 6,R
 	node = tree.root.right
-	assert.Equal(t, 6, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(6), node.key, "got unexpected node val")
 	assert.Equal(t, "six", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour.")
 	assert.NotNil(t, node.left, "expected node to have left child")
@@ -291,7 +297,7 @@ func TestDelete(t *testing.T) {
 
 	// 5, B
 	node = tree.root.right.left
-	assert.Equal(t, 5, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
 	assert.Equal(t, "five", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -299,7 +305,7 @@ func TestDelete(t *testing.T) {
 
 	// 7, B
 	node = tree.root.right.right
-	assert.Equal(t, 7, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
 	assert.Equal(t, "seven", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -307,14 +313,14 @@ func TestDelete(t *testing.T) {
 
 	// 8, R
 	node = tree.root.right.right.right
-	assert.Equal(t, 8, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
 	assert.Equal(t, "eight", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// REMOVE 2
-	assert.True(t, tree.Delete(2), "expected node to be found and removed from tree")
+	assert.True(t, tree.Delete(treeTestInt(2)), "expected node to be found and removed from tree")
 	assert.Equal(t, 6, tree.Size(), "expected tree to have 6 nodes")
 	height, err = validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
@@ -329,7 +335,7 @@ func TestDelete(t *testing.T) {
 
 	// 6,B
 	node = tree.root
-	assert.Equal(t, 6, node.val, "expected tree root val to be 6")
+	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
 	assert.Equal(t, "six", node.str, "expected tree root str to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
@@ -337,7 +343,7 @@ func TestDelete(t *testing.T) {
 
 	// 4,R
 	node = tree.root.left
-	assert.Equal(t, 4, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(4), node.key, "got unexpected node val")
 	assert.Equal(t, "four", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "node should have left child")
@@ -345,7 +351,7 @@ func TestDelete(t *testing.T) {
 
 	// 3,B
 	node = tree.root.left.left
-	assert.Equal(t, 3, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(3), node.key, "got unexpected node val")
 	assert.Equal(t, "three", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -353,7 +359,7 @@ func TestDelete(t *testing.T) {
 
 	// 5,B
 	node = tree.root.left.right
-	assert.Equal(t, 5, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
 	assert.Equal(t, "five", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -361,7 +367,7 @@ func TestDelete(t *testing.T) {
 
 	// 7,B
 	node = tree.root.right
-	assert.Equal(t, 7, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
 	assert.Equal(t, "seven", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -369,14 +375,14 @@ func TestDelete(t *testing.T) {
 
 	// 8,R
 	node = tree.root.right.right
-	assert.Equal(t, 8, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
 	assert.Equal(t, "eight", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// REMOVE 3
-	assert.True(t, tree.Delete(3), "expected node to be found and removed from tree")
+	assert.True(t, tree.Delete(treeTestInt(3)), "expected node to be found and removed from tree")
 	assert.Equal(t, 5, tree.Size(), "expected tree to have 5 nodes")
 	height, err = validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
@@ -391,7 +397,7 @@ func TestDelete(t *testing.T) {
 
 	// 6,B
 	node = tree.root
-	assert.Equal(t, 6, node.val, "expected tree root val to be 6")
+	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
 	assert.Equal(t, "six", node.str, "expected tree root str to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
@@ -399,7 +405,7 @@ func TestDelete(t *testing.T) {
 
 	// 4,B
 	node = tree.root.left
-	assert.Equal(t, 4, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(4), node.key, "got unexpected node val")
 	assert.Equal(t, "four", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -407,7 +413,7 @@ func TestDelete(t *testing.T) {
 
 	// 5,R
 	node = tree.root.left.right
-	assert.Equal(t, 5, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
 	assert.Equal(t, "five", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -415,7 +421,7 @@ func TestDelete(t *testing.T) {
 
 	// 7,B
 	node = tree.root.right
-	assert.Equal(t, 7, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
 	assert.Equal(t, "seven", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -423,14 +429,14 @@ func TestDelete(t *testing.T) {
 
 	// 8,R
 	node = tree.root.right.right
-	assert.Equal(t, 8, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
 	assert.Equal(t, "eight", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// REMOVE 4
-	assert.True(t, tree.Delete(4), "expected node to be found and removed from tree")
+	assert.True(t, tree.Delete(treeTestInt(4)), "expected node to be found and removed from tree")
 	assert.Equal(t, 4, tree.Size(), "expected tree to have 4 nodes")
 	height, err = validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
@@ -445,7 +451,7 @@ func TestDelete(t *testing.T) {
 
 	// 6,B
 	node = tree.root
-	assert.Equal(t, 6, node.val, "expected tree root val to be 6")
+	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
 	assert.Equal(t, "six", node.str, "expected tree root str to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.NotNil(t, node.left, "expected tree root to have left child")
@@ -453,7 +459,7 @@ func TestDelete(t *testing.T) {
 
 	// 5,B
 	node = tree.root.left
-	assert.Equal(t, 5, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(5), node.key, "got unexpected node val")
 	assert.Equal(t, "five", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -461,7 +467,7 @@ func TestDelete(t *testing.T) {
 
 	// 7,B
 	node = tree.root.right
-	assert.Equal(t, 7, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
 	assert.Equal(t, "seven", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -469,14 +475,14 @@ func TestDelete(t *testing.T) {
 
 	// 8,R
 	node = tree.root.right.right
-	assert.Equal(t, 8, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
 	assert.Equal(t, "eight", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// REMOVE 5
-	assert.True(t, tree.Delete(5), "expected node to be found and removed from tree")
+	assert.True(t, tree.Delete(treeTestInt(5)), "expected node to be found and removed from tree")
 	assert.Equal(t, 3, tree.Size(), "expected tree to have 3 nodes")
 	height, err = validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
@@ -489,7 +495,7 @@ func TestDelete(t *testing.T) {
 
 	// 7,B
 	node = tree.root
-	assert.Equal(t, 7, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
 	assert.Equal(t, "seven", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.NotNil(t, node.left, "expected node to have left child")
@@ -497,7 +503,7 @@ func TestDelete(t *testing.T) {
 
 	// 6,B
 	node = tree.root.left
-	assert.Equal(t, 6, node.val, "expected tree root val to be 6")
+	assert.Equal(t, treeTestInt(6), node.key, "expected tree root val to be 6")
 	assert.Equal(t, "six", node.str, "expected tree root str to be 6")
 	assert.Equal(t, false, node.red, "expected tree root to be black")
 	assert.Nil(t, node.left, "expected tree root to have left child")
@@ -505,14 +511,14 @@ func TestDelete(t *testing.T) {
 
 	// 8,R
 	node = tree.root.right
-	assert.Equal(t, 8, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
 	assert.Equal(t, "eight", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// REMOVE 5
-	assert.True(t, tree.Delete(6), "expected node to be found and removed from tree")
+	assert.True(t, tree.Delete(treeTestInt(6)), "expected node to be found and removed from tree")
 	assert.Equal(t, 2, tree.Size(), "expected tree to have 2 nodes")
 	height, err = validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
@@ -525,7 +531,7 @@ func TestDelete(t *testing.T) {
 
 	// 7,B
 	node = tree.root
-	assert.Equal(t, 7, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(7), node.key, "got unexpected node val")
 	assert.Equal(t, "seven", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
@@ -533,14 +539,14 @@ func TestDelete(t *testing.T) {
 
 	// 8,R
 	node = tree.root.right
-	assert.Equal(t, 8, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
 	assert.Equal(t, "eight", node.str, "got unexpected node str")
 	assert.Equal(t, true, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// REMOVE 7
-	assert.True(t, tree.Delete(7), "expected node to be found and removed from tree")
+	assert.True(t, tree.Delete(treeTestInt(7)), "expected node to be found and removed from tree")
 	assert.Equal(t, 1, tree.Size(), "expected tree to have 1 node")
 	height, err = validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
@@ -551,14 +557,14 @@ func TestDelete(t *testing.T) {
 
 	// 8,B
 	node = tree.root
-	assert.Equal(t, 8, node.val, "got unexpected node val")
+	assert.Equal(t, treeTestInt(8), node.key, "got unexpected node val")
 	assert.Equal(t, "eight", node.str, "got unexpected node str")
 	assert.Equal(t, false, node.red, "got unexpected node colour")
 	assert.Nil(t, node.left, "expected node to have no left child")
 	assert.Nil(t, node.right, "expected node to have no right child")
 
 	// REMOVE 7
-	assert.True(t, tree.Delete(8), "expected node to be found and removed from tree")
+	assert.True(t, tree.Delete(treeTestInt(8)), "expected node to be found and removed from tree")
 	assert.Equal(t, 0, tree.Size(), "expected tree to be empty")
 	height, err = validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
@@ -567,7 +573,7 @@ func TestDelete(t *testing.T) {
 	// EMPTY TREE!
 	assert.Nil(t, tree.root, "tree root is nil")
 
-	assert.False(t, tree.Delete(1), "success, expected deletion to fail with empty tree")
+	assert.False(t, tree.Delete(treeTestInt(1)), "success, expected deletion to fail with empty tree")
 	assert.Equal(t, 0, tree.Size(), "expected tree to be empty")
 	height, err = validateRedBlackTree(tree.root)
 	assert.NoError(t, err, "expected tree to be a valid red black tree")
@@ -577,7 +583,7 @@ func TestDelete(t *testing.T) {
 func TestSearchEmpty(t *testing.T) {
 	tree := redBlackTree{}
 
-	str, ok := tree.Search(5)
+	str, ok := tree.Search(treeTestInt(5))
 	assert.False(t, ok, "expected node to not be found")
 	assert.Equal(t, "", str, "expected str to be empty")
 }
@@ -593,19 +599,19 @@ func TestSearch(t *testing.T) {
 	//                             \
 	//                              8,R
 
-	str, ok := tree.Search(5)
+	str, ok := tree.Search(treeTestInt(5))
 	assert.True(t, ok, "expected node to be found")
 	assert.Equal(t, "five", str, "expected str to be five")
 
-	str, ok = tree.Search(3)
+	str, ok = tree.Search(treeTestInt(3))
 	assert.True(t, ok, "expected node to be found")
 	assert.Equal(t, "three", str, "expected str to be three")
 
-	str, ok = tree.Search(8)
+	str, ok = tree.Search(treeTestInt(8))
 	assert.True(t, ok, "expected node to be found")
 	assert.Equal(t, "eight", str, "expected str to be three")
 
-	str, ok = tree.Search(9)
+	str, ok = tree.Search(treeTestInt(9))
 	assert.False(t, ok, "expected node to not be found")
 	assert.Equal(t, "", str, "expected str to be empty")
 }
@@ -616,7 +622,7 @@ func TestBig(t *testing.T) {
 
 	for i := 0; i < 2000; i++ {
 		n := random.Intn(10000)
-		tree.Insert(n, strconv.Itoa(n))
+		tree.Insert(treeTestInt(n), strconv.Itoa(n))
 	}
 
 	_, err := validateRedBlackTree(tree.root)
@@ -624,7 +630,7 @@ func TestBig(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		n := random.Intn(10000)
-		tree.Delete(n)
+		tree.Delete(treeTestInt(n))
 	}
 
 	_, err = validateRedBlackTree(tree.root)
@@ -641,7 +647,7 @@ func BenchmarkRedBlackTreeInsert(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		tree := redBlackTree{}
 		for i := 0; i < 1000000; i++ {
-			tree.Insert(i, "something")
+			tree.Insert(treeTestInt(i), "something")
 		}
 	}
 }
@@ -652,12 +658,12 @@ func BenchmarkRedBlackTreeDelete(b *testing.B) {
 		// stop timer while tree is created
 		tree := redBlackTree{}
 		for i := 0; i < 1000000; i++ {
-			tree.Insert(i, "something")
+			tree.Insert(treeTestInt(i), "something")
 		}
 		b.StartTimer()
 		// restart timer and time only deletion
 		for i := 0; i < 1000000; i++ {
-			tree.Delete(i)
+			tree.Delete(treeTestInt(i))
 		}
 	}
 }
@@ -666,12 +672,12 @@ func BenchmarkRedBlackTreeSearch(b *testing.B) {
 	b.StopTimer()
 	tree := redBlackTree{}
 	for i := 0; i < 1000000; i++ {
-		tree.Insert(i, "something")
+		tree.Insert(treeTestInt(i), "something")
 	}
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < 1000000; i++ {
-			tree.Search(i)
+			tree.Search(treeTestInt(i))
 		}
 	}
 }

--- a/hashring/rbtree_test.go
+++ b/hashring/rbtree_test.go
@@ -32,8 +32,8 @@ import (
 
 type treeTestInt int
 
-func (me treeTestInt) Compare(other interface{}) int {
-	return int(me) - int(other.(treeTestInt))
+func (t treeTestInt) Compare(other interface{}) int {
+	return int(t) - int(other.(treeTestInt))
 }
 
 //= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =


### PR DESCRIPTION
This is the first part of identity carry over where we abstract the RBTree to not care about the datatypes stored as long as the key is sortable via a Compare function it will create a RBTree.

This will help in later stages where the `keytype` will be a struct with more data points instead of a string.