### PR TITLE
fix: make lookups consistent on hash collisions

### DIFF
--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -61,16 +61,19 @@ type replicaPoint struct {
 
 func (r replicaPoint) Compare(other interface{}) (result int) {
 	o := other.(replicaPoint)
+
 	result = r.hash - o.hash
-	if result == 0 {
-		result = strings.Compare(r.address, o.address)
+	if result != 0 {
+		return
 	}
 
-	if result == 0 {
-		result = r.index - o.index
+	result = strings.Compare(r.address, o.address)
+	if result != 0 {
+		return
 	}
 
-	return result
+	result = r.index - o.index
+	return
 }
 
 // HashRing stores strings on a consistent hash ring. HashRing internally uses

--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -24,13 +24,12 @@ package hashring
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/uber/ringpop-go/events"
 	"github.com/uber/ringpop-go/logging"
 	"github.com/uber/ringpop-go/membership"
-
-	"strings"
 
 	"github.com/uber-common/bark"
 )

--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -55,16 +55,23 @@ type replicaPoint struct {
 
 	// address of the member that owns this replicaPoint.
 	address string
+
+	// index of the replica point for a member
+	index int
 }
 
-func (r replicaPoint) Compare(other interface{}) int {
+func (r replicaPoint) Compare(other interface{}) (result int) {
 	o := other.(replicaPoint)
-	result := r.hash - o.hash
-	if result != 0 {
-		return result
+	result = r.hash - o.hash
+	if result == 0 {
+		result = strings.Compare(r.address, o.address)
 	}
 
-	return strings.Compare(r.address, o.address)
+	if result == 0 {
+		result = r.index - o.index
+	}
+
+	return result
 }
 
 // HashRing stores strings on a consistent hash ring. HashRing internally uses
@@ -193,6 +200,7 @@ func (r *HashRing) replicaPointForServer(server membership.Member, replica int) 
 		hash:     r.hashfunc(replicaStr),
 		identity: identity,
 		address:  server.GetAddress(),
+		index:    replica,
 	}
 }
 

--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -30,6 +30,8 @@ import (
 	"github.com/uber/ringpop-go/logging"
 	"github.com/uber/ringpop-go/membership"
 
+	"strings"
+
 	"github.com/uber-common/bark"
 )
 
@@ -56,7 +58,13 @@ type replicaPoint struct {
 }
 
 func (r replicaPoint) Compare(other interface{}) int {
-	return r.hash - other.(replicaPoint).hash
+	o := other.(replicaPoint)
+	result := r.hash - o.hash
+	if result != 0 {
+		return result
+	}
+
+	return strings.Compare(r.address, o.address)
 }
 
 // HashRing stores strings on a consistent hash ring. HashRing internally uses

--- a/hashring/hashring_test.go
+++ b/hashring/hashring_test.go
@@ -518,15 +518,17 @@ func TestLookupsWithIdentities(t *testing.T) {
 func TestReplicaPointCompare(t *testing.T) {
 	address := "127.0.0.1:3000"
 
-	pointA := replicaPoint{hash: 100, address: address}
-	pointB := replicaPoint{hash: 200, address: address}
-	pointC := replicaPoint{hash: 300, address: address}
-	pointD := replicaPoint{hash: 200, address: address}
+	pointA := replicaPoint{hash: 100, address: address, index: 0}
+	pointB := replicaPoint{hash: 200, address: address, index: 0}
+	pointC := replicaPoint{hash: 300, address: address, index: 0}
+	pointD := replicaPoint{hash: 200, address: address, index: 0}
+	pointE := replicaPoint{hash: 200, address: address, index: 1}
 
 	assert.True(t, pointB.Compare(pointA) > 0)
 	assert.True(t, pointB.Compare(pointC) < 0)
 	assert.True(t, pointB.Compare(pointB) == 0)
 	assert.True(t, pointB.Compare(pointD) == 0)
+	assert.True(t, pointB.Compare(pointE) < 0)
 }
 
 func genMembers(host, fromPort, toPort int, overrideIdentity bool) (members []membership.Member) {

--- a/hashring/hashring_test.go
+++ b/hashring/hashring_test.go
@@ -98,6 +98,32 @@ func TestRemoveMembers(t *testing.T) {
 	assert.False(t, ring.HasServer("server3"), "expected server to not be in ring")
 }
 
+func TestConsistentLookupsOnDuplicates(t *testing.T) {
+	ring1 := New(farm.Fingerprint32, 10)
+	ring2 := New(farm.Fingerprint32, 10)
+
+	member1 := fakeMember{
+		address:  "server1",
+		identity: "id",
+	}
+	member2 := fakeMember{
+		address:  "server2",
+		identity: "id",
+	}
+
+	ring1.AddMembers(member1)
+	ring1.AddMembers(member2)
+
+	// add in different order
+	ring2.AddMembers(member2)
+	ring2.AddMembers(member1)
+
+	lookup1, _ := ring1.Lookup("id#1")
+	lookup2, _ := ring2.Lookup("id#1")
+	assert.Equal(t, lookup1, lookup2, "Order of adds does not affect lookups")
+	assert.Equal(t, ring1.checksums["replica"], ring2.checksums["replica"], "Order of adds does not affect checksums")
+}
+
 func TestChecksumChanges(t *testing.T) {
 	ring := New(farm.Fingerprint32, 10)
 	checksum := ring.Checksum()


### PR DESCRIPTION
Previously, if a replica point of a member overlapped with an already existing replica point, the order of addition mattered for the lookups. This caused potential inconsistencies across the cluster. By comparing the addresses of the replica points on hash collision, the order of adding the servers doesn't matter anymore.

note: this is basically a new version of #147