### PR TITLE
Fix: remove error log for counting members during bootstrap

### DIFF
--- a/ringpop.go
+++ b/ringpop.go
@@ -477,11 +477,16 @@ func (rp *Ringpop) HandleEvent(event events.Event) {
 			}
 			rp.statter.IncCounter(rp.getStatKey("membership-set."+status), nil, 1)
 		}
-		mc, err := rp.CountReachableMembers()
-		if err != nil {
-			rp.logger.Errorf("unable to count members of the ring for statting: %q", err)
-		} else {
-			rp.statter.UpdateGauge(rp.getStatKey("num-members"), nil, int64(mc))
+		// During bootstrapping ringpop is not ready causing errors from
+		// CountReachableMembers. When this is logged it would confuse people
+		// thinking that there is a problem with ringpop bootstrapping
+		if rp.Ready() {
+			mc, err := rp.CountReachableMembers()
+			if err != nil {
+				rp.logger.Errorf("unable to count members of the ring for statting: %q", err)
+			} else {
+				rp.statter.UpdateGauge(rp.getStatKey("num-members"), nil, int64(mc))
+			}
 		}
 		rp.statter.IncCounter(rp.getStatKey("updates"), nil, int64(len(event.Changes)))
 


### PR DESCRIPTION
During bootstrap an error log was written that it couldn't count members due to ringpop not being bootstrapped. This is confusing.

This diff prevents the stat and therefore the log to be emitted before bootstrap has finished.