### PR TITLE
Add WithError() to NoLogger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - ./scripts/travis/get-thrift.sh
   - ./scripts/travis/get-thrift-gen.sh
   - ./scripts/travis/get-cram.sh
-  - npm install -g tcurl
+  - npm install -g tcurl@v4.22.2
   - make setup
 
 env:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 ringpop-go changes
 ==================
 
+v0.8.2
+------
+
+* Fix: Add WithError() to NoLogger [#203](https://github.com/uber/ringpop-go/pull/203)
+
 v0.8.1
 ------
 

--- a/logging/named.go
+++ b/logging/named.go
@@ -29,6 +29,7 @@ import (
 type namedLogger struct {
 	name      string
 	forwardTo logReceiver
+	err       error
 	fields    bark.Fields
 }
 
@@ -100,6 +101,17 @@ func (l *namedLogger) WithFields(fields bark.LogFields) bark.Logger {
 		name:      l.name,
 		forwardTo: l.forwardTo,
 		fields:    newFields,
+	}
+}
+
+// Return a new named logger with the error set to be included in a subsequent
+// normal logging call
+func (l *namedLogger) WithError(err error) bark.Logger {
+	return &namedLogger{
+		name:      l.name,
+		forwardTo: l.ForwardTo,
+		err:       err,
+		fields:    l.Fields(),
 	}
 }
 

--- a/logging/named.go
+++ b/logging/named.go
@@ -109,7 +109,7 @@ func (l *namedLogger) WithFields(fields bark.LogFields) bark.Logger {
 func (l *namedLogger) WithError(err error) bark.Logger {
 	return &namedLogger{
 		name:      l.name,
-		forwardTo: l.ForwardTo,
+		forwardTo: l.forwardTo,
 		err:       err,
 		fields:    l.Fields(),
 	}

--- a/logging/nologger.go
+++ b/logging/nologger.go
@@ -42,6 +42,7 @@ func (l noLogger) Panic(args ...interface{})                           {}
 func (l noLogger) Panicf(format string, args ...interface{})           {}
 func (l noLogger) WithField(key string, value interface{}) bark.Logger { return l }
 func (l noLogger) WithFields(keyValues bark.LogFields) bark.Logger     { return l }
+func (l noLogger) WithError(err error) bark.Logger                     { return l }
 func (l noLogger) Fields() bark.Fields                                 { return nil }
 
 // NoLogger is the default logger used by logging facilities when a logger

--- a/logging/nologger.go
+++ b/logging/nologger.go
@@ -47,4 +47,4 @@ func (l noLogger) Fields() bark.Fields                                 { return 
 
 // NoLogger is the default logger used by logging facilities when a logger
 // is not passed.
-var NoLogger = noLogger{}
+var NoLogger bark.Logger = noLogger{}


### PR DESCRIPTION
The Bark logger interface now has a `WithError(err Error) bark.Logger` method. Just adding that to the NoLogger interface.