### PR TITLE
Test on recent Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.7
-  - 1.6
+  - 1.7.x
+  - 1.8.x
 
 addons:
   apt:


### PR DESCRIPTION
We're using out-of-date Go versions in CI. This PR updates us to test on
the last two stable minor releases.