### PR TITLE
hashring.LookupN returns ordered results

### DIFF
--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -391,9 +391,9 @@ func (r *HashRing) lookupNNoLock(key string, n int) []string {
 	// collected all the servers we want, we have reached the
 	// end of the red-black tree and we need to loop around and inspect the
 	// tree starting at 0.
-	r.tree.LookupNUniqueAt(n, replicaPoint{hash: hash}, unique, &orderedUnique)
+	r.tree.LookupOrderedNUniqueAt(n, replicaPoint{hash: hash}, unique, &orderedUnique)
 	if len(unique) < n {
-		r.tree.LookupNUniqueAt(n, replicaPoint{hash: 0}, unique, &orderedUnique)
+		r.tree.LookupOrderedNUniqueAt(n, replicaPoint{hash: 0}, unique, &orderedUnique)
 	}
 
 	var servers []string

--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -383,10 +383,6 @@ func (r *HashRing) LookupN(key string, n int) []string {
 
 // This function isn't thread-safe, only call it when the HashRing is locked.
 func (r *HashRing) lookupNNoLock(key string, n int) []string {
-	if n >= len(r.serverSet) {
-		return r.copyServersNoLock()
-	}
-
 	hash := r.hashfunc(key)
 	unique := make(map[valuetype]struct{})
 	orderedUnique := make([]valuetype, 0, n)

--- a/hashring/hashring.go
+++ b/hashring/hashring.go
@@ -389,18 +389,19 @@ func (r *HashRing) lookupNNoLock(key string, n int) []string {
 
 	hash := r.hashfunc(key)
 	unique := make(map[valuetype]struct{})
+	orderedUnique := make([]valuetype, 0, n)
 
 	// lookup N unique servers from the red-black tree. If we have not
 	// collected all the servers we want, we have reached the
 	// end of the red-black tree and we need to loop around and inspect the
 	// tree starting at 0.
-	r.tree.LookupNUniqueAt(n, replicaPoint{hash: hash}, unique)
+	r.tree.LookupNUniqueAt(n, replicaPoint{hash: hash}, unique, &orderedUnique)
 	if len(unique) < n {
-		r.tree.LookupNUniqueAt(n, replicaPoint{hash: 0}, unique)
+		r.tree.LookupNUniqueAt(n, replicaPoint{hash: 0}, unique, &orderedUnique)
 	}
 
 	var servers []string
-	for server := range unique {
+	for _, server := range orderedUnique {
 		servers = append(servers, server.(string))
 	}
 	return servers

--- a/hashring/hashring_test.go
+++ b/hashring/hashring_test.go
@@ -310,8 +310,7 @@ func TestLookupNLoopAround(t *testing.T) {
 	ring.AddMembers(members...)
 
 	unique := make(map[valuetype]struct{})
-	orderedUnique := make([]valuetype, 0, 1)
-	ring.tree.LookupNUniqueAt(1, replicaPoint{hash: 0}, unique, &orderedUnique)
+	ring.tree.LookupNUniqueAt(1, replicaPoint{hash: 0}, unique)
 	var firstInTree valuetype
 	for server := range unique {
 		firstInTree = server

--- a/hashring/hashring_test.go
+++ b/hashring/hashring_test.go
@@ -399,7 +399,7 @@ func (s *ProcessMembershipChangesSuite) TestAddMember0() {
 	s.ring.ProcessMembershipChanges([]membership.MemberChange{
 		{After: s.members[0]},
 	})
-	mock.AssertExpectationsForObjects(s.T(), s.l.Mock)
+	mock.AssertExpectationsForObjects(s.T(), &s.l.Mock)
 	s.Equal(1, s.ring.ServerCount(), "unexpected count of members in ring")
 }
 
@@ -411,7 +411,7 @@ func (s *ProcessMembershipChangesSuite) TestAddMember1() {
 	s.ring.ProcessMembershipChanges([]membership.MemberChange{
 		{After: s.members[1]},
 	})
-	mock.AssertExpectationsForObjects(s.T(), s.l.Mock)
+	mock.AssertExpectationsForObjects(s.T(), &s.l.Mock)
 	s.Equal(2, s.ring.ServerCount(), "unexpected count of members in ring")
 }
 
@@ -425,7 +425,7 @@ func (s *ProcessMembershipChangesSuite) TestRemoveMember0AddMember2() {
 		{After: s.members[2]},
 		{Before: s.members[0]},
 	})
-	mock.AssertExpectationsForObjects(s.T(), s.l.Mock)
+	mock.AssertExpectationsForObjects(s.T(), &s.l.Mock)
 	s.Equal(2, s.ring.ServerCount(), "unexpected count of members in ring")
 }
 
@@ -453,7 +453,7 @@ func (s *ProcessMembershipChangesSuite) TestChangeIdentityMember2() {
 	s.ring.ProcessMembershipChanges([]membership.MemberChange{
 		{Before: s.members[1], After: memberNewIdentity},
 	})
-	mock.AssertExpectationsForObjects(s.T(), s.l.Mock)
+	mock.AssertExpectationsForObjects(s.T(), &s.l.Mock)
 	s.Equal(2, s.ring.ServerCount(), "unexpected count of members in ring")
 }
 

--- a/hashring/hashring_test.go
+++ b/hashring/hashring_test.go
@@ -311,7 +311,7 @@ func TestLookupNLoopAround(t *testing.T) {
 
 	unique := make(map[valuetype]struct{})
 	orderedUnique := make([]valuetype, 0, 1)
-	ring.tree.LookupNUniqueAt(1, replicaPoint{hash: 0}, unique, orderedUnique)
+	ring.tree.LookupNUniqueAt(1, replicaPoint{hash: 0}, unique, &orderedUnique)
 	var firstInTree valuetype
 	for server := range unique {
 		firstInTree = server

--- a/hashring/hashring_test.go
+++ b/hashring/hashring_test.go
@@ -310,7 +310,8 @@ func TestLookupNLoopAround(t *testing.T) {
 	ring.AddMembers(members...)
 
 	unique := make(map[valuetype]struct{})
-	ring.tree.LookupNUniqueAt(1, replicaPoint{hash: 0}, unique)
+	orderedUnique := make([]valuetype, 0, 1)
+	ring.tree.LookupNUniqueAt(1, replicaPoint{hash: 0}, unique, orderedUnique)
 	var firstInTree valuetype
 	for server := range unique {
 		firstInTree = server

--- a/hashring/hashring_test.go
+++ b/hashring/hashring_test.go
@@ -400,7 +400,7 @@ func (s *ProcessMembershipChangesSuite) TestAddMember0() {
 	s.ring.ProcessMembershipChanges([]membership.MemberChange{
 		{After: s.members[0]},
 	})
-	mock.AssertExpectationsForObjects(s.T(), &s.l.Mock)
+	mock.AssertExpectationsForObjects(s.T(), s.l.Mock)
 	s.Equal(1, s.ring.ServerCount(), "unexpected count of members in ring")
 }
 
@@ -412,7 +412,7 @@ func (s *ProcessMembershipChangesSuite) TestAddMember1() {
 	s.ring.ProcessMembershipChanges([]membership.MemberChange{
 		{After: s.members[1]},
 	})
-	mock.AssertExpectationsForObjects(s.T(), &s.l.Mock)
+	mock.AssertExpectationsForObjects(s.T(), s.l.Mock)
 	s.Equal(2, s.ring.ServerCount(), "unexpected count of members in ring")
 }
 
@@ -426,7 +426,7 @@ func (s *ProcessMembershipChangesSuite) TestRemoveMember0AddMember2() {
 		{After: s.members[2]},
 		{Before: s.members[0]},
 	})
-	mock.AssertExpectationsForObjects(s.T(), &s.l.Mock)
+	mock.AssertExpectationsForObjects(s.T(), s.l.Mock)
 	s.Equal(2, s.ring.ServerCount(), "unexpected count of members in ring")
 }
 
@@ -454,7 +454,7 @@ func (s *ProcessMembershipChangesSuite) TestChangeIdentityMember2() {
 	s.ring.ProcessMembershipChanges([]membership.MemberChange{
 		{Before: s.members[1], After: memberNewIdentity},
 	})
-	mock.AssertExpectationsForObjects(s.T(), &s.l.Mock)
+	mock.AssertExpectationsForObjects(s.T(), s.l.Mock)
 	s.Equal(2, s.ring.ServerCount(), "unexpected count of members in ring")
 }
 

--- a/hashring/rbtree.go
+++ b/hashring/rbtree.go
@@ -303,8 +303,18 @@ func (t *redBlackTree) Search(key keytype) (valuetype, bool) {
 
 // LookupNUniqueAt iterates through the tree from the last node that is smaller
 // than key or equal, and returns the next n unique values. This function is not
-// guaranteed to return n values, less might be returned
-func (t *redBlackTree) LookupNUniqueAt(n int, key keytype, result map[valuetype]struct{}, orderedResult *[]valuetype) {
+// guaranteed to return n values, less might be returned. Because this function
+// relies on writing the unique values to a golang map type, order cannot be
+// inferred. DEPRECATED, but maintained for backwards compatibility.
+func (t *redBlackTree) LookupNUniqueAt(n int, key keytype, result map[valuetype]struct{}) {
+	findNUniqueAbove(t.root, n, key, result, nil)
+}
+
+// LookupOrderedNUniqueAt iterates through the tree from the last node that is
+// smaller than key or equal, and returns the next n unique values. This function
+// is not guaranteed to return n values, less might be returned. This method
+// replaces LookupNUniqueAt since it uses a slice to guarantee order.
+func (t *redBlackTree) LookupOrderedNUniqueAt(n int, key keytype, result map[valuetype]struct{}, orderedResult *[]valuetype) {
 	findNUniqueAbove(t.root, n, key, result, orderedResult)
 }
 
@@ -327,7 +337,7 @@ func findNUniqueAbove(node *redBlackNode, n int, key keytype, result map[valuety
 	}
 
 	if cmp >= 0 {
-		if _, ok := result[node.value]; !ok {
+		if _, ok := result[node.value]; !ok && orderedResult != nil {
 			*orderedResult = append(*orderedResult, node.value)
 		}
 		result[node.value] = struct{}{}

--- a/hashring/rbtree.go
+++ b/hashring/rbtree.go
@@ -304,13 +304,13 @@ func (t *redBlackTree) Search(key keytype) (valuetype, bool) {
 // LookupNUniqueAt iterates through the tree from the last node that is smaller
 // than key or equal, and returns the next n unique values. This function is not
 // guaranteed to return n values, less might be returned
-func (t *redBlackTree) LookupNUniqueAt(n int, key keytype, result map[valuetype]struct{}) {
-	findNUniqueAbove(t.root, n, key, result)
+func (t *redBlackTree) LookupNUniqueAt(n int, key keytype, result map[valuetype]struct{}, orderedResult *[]valuetype) {
+	findNUniqueAbove(t.root, n, key, result, orderedResult)
 }
 
 // findNUniqueAbove is a recursive search that finds n unique values with a key
 // bigger or equal than key
-func findNUniqueAbove(node *redBlackNode, n int, key keytype, result map[valuetype]struct{}) {
+func findNUniqueAbove(node *redBlackNode, n int, key keytype, result map[valuetype]struct{}, orderedResult *[]valuetype) {
 	if len(result) >= n || node == nil {
 		return
 	}
@@ -318,7 +318,7 @@ func findNUniqueAbove(node *redBlackNode, n int, key keytype, result map[valuety
 	// skip left branch when all its keys are smaller than key
 	cmp := node.key.Compare(key)
 	if cmp >= 0 {
-		findNUniqueAbove(node.left, n, key, result)
+		findNUniqueAbove(node.left, n, key, result, orderedResult)
 	}
 
 	// Make sure to stop when we have n unique values
@@ -327,8 +327,11 @@ func findNUniqueAbove(node *redBlackNode, n int, key keytype, result map[valuety
 	}
 
 	if cmp >= 0 {
+		if _, ok := result[node.value]; !ok {
+			*orderedResult = append(*orderedResult, node.value)
+		}
 		result[node.value] = struct{}{}
 	}
 
-	findNUniqueAbove(node.right, n, key, result)
+	findNUniqueAbove(node.right, n, key, result, orderedResult)
 }


### PR DESCRIPTION
The previous implementation of LookupN used a map internally to guarantee uniqueness, but when converted to a slice, ordering of servers in the hashring is lost. This diff updates the internal implementation to maintain a pointer to a slice that is appended during the depth-first search of the red-black tree. This ordered result is converted to a slice of strings to return to the caller.

cc/ @yulunli @akshayjshah 