### PR TITLE
Update tchannel version and add a context option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lint.log
 /_venv/
 README.md.err
 tick-cluster.log
+.idea/

--- a/examples/keyvalue/gen-go/keyvalue/tchan-keyvalue.go
+++ b/examples/keyvalue/gen-go/keyvalue/tchan-keyvalue.go
@@ -45,6 +45,10 @@ func (c *tchanKeyValueServiceClient) Get(ctx thrift.Context, key string) (string
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "Get", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Get")
+		}
 	}
 
 	return resp.GetSuccess(), err
@@ -57,6 +61,10 @@ func (c *tchanKeyValueServiceClient) GetAll(ctx thrift.Context, keys []string) (
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "GetAll", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for GetAll")
+		}
 	}
 
 	return resp.GetSuccess(), err
@@ -70,6 +78,10 @@ func (c *tchanKeyValueServiceClient) Set(ctx thrift.Context, key string, value s
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "Set", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Set")
+		}
 	}
 
 	return err

--- a/examples/ping-thrift-gen/gen-go/ping/tchan-ping.go
+++ b/examples/ping-thrift-gen/gen-go/ping/tchan-ping.go
@@ -43,6 +43,10 @@ func (c *tchanPingPongServiceClient) Ping(ctx thrift.Context, request *Ping) (*P
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "Ping", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Ping")
+		}
 	}
 
 	return resp.GetSuccess(), err

--- a/examples/role-labels/gen-go/role/tchan-role.go
+++ b/examples/role-labels/gen-go/role/tchan-role.go
@@ -44,6 +44,10 @@ func (c *tchanRoleServiceClient) GetMembers(ctx thrift.Context, role string) ([]
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "GetMembers", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for GetMembers")
+		}
 	}
 
 	return resp.GetSuccess(), err
@@ -56,6 +60,10 @@ func (c *tchanRoleServiceClient) SetRole(ctx thrift.Context, role string) error 
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "SetRole", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for SetRole")
+		}
 	}
 
 	return err

--- a/forward/forwarder.go
+++ b/forward/forwarder.go
@@ -47,6 +47,7 @@ type Sender interface {
 
 // Options for the creation of a forwarder
 type Options struct {
+	Ctx            thrift.Context
 	MaxRetries     int
 	RerouteRetries bool
 	RetrySchedule  []time.Duration
@@ -80,6 +81,7 @@ func (f *Forwarder) mergeDefaultOptions(opts *Options) *Options {
 		merged.RetrySchedule = def.RetrySchedule
 	}
 	merged.Headers = opts.Headers
+	merged.Ctx = opts.Ctx
 
 	return &merged
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 81dea72207381ddfa6c441ae89ae4a7c93b597ded0912f972fdb11298130b8d6
-updated: 2017-07-26T17:10:07.640390059-07:00
+hash: 817fc2593a62fb630719d72c41e784ae6bed059238785076e5764fe90fb4b26a
+updated: 2017-11-10T15:29:25.849080805-08:00
 imports:
 - name: github.com/apache/thrift
   version: 5bc8b5a3a5da507b6f87436ca629be664496a69f
@@ -12,19 +12,20 @@ imports:
   subpackages:
   - statsd
 - name: github.com/davecgh/go-spew
-  version: adab96458c51a58dc1783b3335dcce5461522e75
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/dgryski/go-farm
   version: fc41e106ee0e4394f69a56046e5c5adbaf29d912
 - name: github.com/opentracing/opentracing-go
-  version: 77a31d686003349e89c89e58408aafcd20003f41
+  version: 1949ddbfd147afd4d964a9f00b24eb291e0e7c38
   subpackages:
   - ext
+  - log
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/rcrowley/go-metrics
@@ -32,7 +33,7 @@ imports:
 - name: github.com/sirupsen/logrus
   version: abee6f9b0679f8044f5fca552eb6a9691a55d4ac
 - name: github.com/stretchr/objx
-  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 05e8a0eda380579888eb53c394909df027f06991
   subpackages:
@@ -43,10 +44,13 @@ imports:
 - name: github.com/uber-common/bark
   version: dbf558e8a7b65e2b54e1e01c14ee0e4207a865f5
 - name: github.com/uber-go/atomic
-  version: 0c9e689d64f004564b79d9a663634756df322902
-- name: github.com/uber/tchannel-go
-  version: 1a0e35378f6f721bc07f6c4466bc9701ed70b506
+  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
   subpackages:
+  - utils
+- name: github.com/uber/tchannel-go
+  version: cc230a2942d078a8b01f4a79895dad62e6c572f1
+  subpackages:
+  - internal/argreader
   - json
   - raw
   - relay
@@ -54,12 +58,18 @@ imports:
   - thrift/gen-go/meta
   - thrift/thrift-gen
   - tnet
+  - tos
   - trand
   - typed
 - name: golang.org/x/net
   version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
   subpackages:
+  - bpf
   - context
+  - internal/iana
+  - internal/socket
+  - ipv4
+  - ipv6
 - name: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,6 +14,7 @@ import:
   - require
 - package: github.com/uber-common/bark
 - package: github.com/uber/tchannel-go
+  version: 1.8.0
   subpackages:
   - json
   - raw


### PR DESCRIPTION
Update tchannel version and add a context option so clients using Ringpop.Forward have a way of passing tracing spans across ringpop. 