### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/logging/named.go
+++ b/logging/named.go
@@ -104,7 +104,7 @@ func (l *namedLogger) WithFields(fields bark.LogFields) bark.Logger {
 	}
 }
 
-// Return a new named logger with the error set to be included in a subsequent
+// WithError returns a new named logger with the error set to be included in a subsequent
 // normal logging call
 func (l *namedLogger) WithError(err error) bark.Logger {
 	return &namedLogger{
@@ -115,7 +115,7 @@ func (l *namedLogger) WithError(err error) bark.Logger {
 	}
 }
 
-// This is needed to fully implement the bark.Logger interface.
+// Fields is needed to fully implement the bark.Logger interface.
 func (l *namedLogger) Fields() bark.Fields {
 	return l.fields
 }

--- a/router/router.go
+++ b/router/router.go
@@ -98,7 +98,7 @@ func (r *router) handleChange(change swim.Change) {
 	}
 }
 
-// Get the client for a certain destination from our internal cache, or
+// GetClient gets the client for a certain destination from our internal cache, or
 // delegates the creation to the ClientFactory.
 func (r *router) GetClient(key string) (client interface{}, isRemote bool, err error) {
 	dest, err := r.ringpop.Lookup(key)

--- a/swim/gossip.go
+++ b/swim/gossip.go
@@ -161,7 +161,7 @@ func (g *gossip) Stop() {
 	g.logger.Debug("stopped gossip protocol")
 }
 
-// returns whether or not the gossip sub-protocol is stopped
+// Stopped returns whether or not the gossip sub-protocol is stopped
 func (g *gossip) Stopped() bool {
 	g.state.RLock()
 	stopped := !g.state.running

--- a/swim/memberlist.go
+++ b/swim/memberlist.go
@@ -142,7 +142,7 @@ func (m *memberlist) genChecksumString() string {
 	return buffer.String()
 }
 
-// returns the member at a specific address
+// Member returns the member at a specific address
 func (m *memberlist) Member(address string) (*Member, bool) {
 	var memberCopy *Member
 	m.members.RLock()
@@ -207,14 +207,14 @@ func (m *memberlist) NumMembers() int {
 	return n
 }
 
-// returns whether or not a member is pingable
+// Pingable returns whether or not a member is pingable
 func (m *memberlist) Pingable(member Member) bool {
 	return member.Address != m.local.Address &&
 		(member.Status == Alive || member.Status == Suspect)
 
 }
 
-// returns the number of pingable members in the memberlist
+// NumPingableMembers returns the number of pingable members in the memberlist
 func (m *memberlist) NumPingableMembers() (n int) {
 	m.members.RLock()
 	for _, member := range m.members.list {
@@ -227,7 +227,7 @@ func (m *memberlist) NumPingableMembers() (n int) {
 	return n
 }
 
-// returns n pingable members in the member list
+// RandomPingableMembers returns n pingable members in the member list
 func (m *memberlist) RandomPingableMembers(n int, excluding map[string]bool) []Member {
 	members := make([]Member, 0, n)
 
@@ -246,7 +246,7 @@ func (m *memberlist) RandomPingableMembers(n int, excluding map[string]bool) []M
 	return members
 }
 
-// returns an slice of (copied) members representing the current state of the
+// GetMembers returns an slice of (copied) members representing the current state of the
 // membership. The membership will be filtered by the predicates provided.
 func (m *memberlist) GetMembers(predicates ...MemberPredicate) (members []Member) {
 	m.members.RLock()


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._